### PR TITLE
[feat] 사용자 프로필 이미지 변경 기능 추가 #61

### DIFF
--- a/src/main/java/com/example/controller/member/MemberController.java
+++ b/src/main/java/com/example/controller/member/MemberController.java
@@ -5,6 +5,7 @@ import com.example.dto.request.AddPointRequest;
 import com.example.dto.request.ChangeEmailRequest;
 import com.example.dto.request.ChangePwdRequest;
 import com.example.dto.request.ChangeUsernameRequest;
+import com.example.dto.request.ChangeProfileImageRequest;
 import com.example.service.member.MemberService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -66,6 +67,17 @@ public class MemberController {
 
         return memberService.changeUsername(changeUsernameRequest,userDetails.getUsername());
     }
+    /*
+    프로필 이미지 변경
+    */
+    @PatchMapping("/change-profile-image")
+    @Operation(summary = "프로필 이미지 변경", description = "")
+    public ApiResult<?> changeProfileImage(@RequestBody ChangeProfileImageRequest changeProfileImageRequest,
+                                           @AuthenticationPrincipal UserDetails userDetails) {
+        return memberService.changeProfileImage(changeProfileImageRequest, userDetails.getUsername());
+    }
+
+
 
 
 }

--- a/src/main/java/com/example/domain/member/Member.java
+++ b/src/main/java/com/example/domain/member/Member.java
@@ -30,7 +30,7 @@ public class Member {
 
     private Integer point;
 
-    private String profileImagePathUrl;
+    private String profile_path;
 
 
     @Enumerated(EnumType.STRING)

--- a/src/main/java/com/example/dto/request/ChangeProfileImageRequest.java
+++ b/src/main/java/com/example/dto/request/ChangeProfileImageRequest.java
@@ -1,0 +1,12 @@
+package com.example.dto.request;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+public class ChangeProfileImageRequest {
+    private String profileImagePathUrl;
+}

--- a/src/main/java/com/example/service/community/CommunityService.java
+++ b/src/main/java/com/example/service/community/CommunityService.java
@@ -226,7 +226,7 @@ public class CommunityService {
                     .author(MyPostResponse.Author.builder()
                             .memberId(member.getMemberId())
                             .username(member.getUsername())
-                            .profileImagePathUrl(member.getProfileImagePathUrl())
+                            .profileImagePathUrl(member.getProfile_path())
                             .build())
                     .tags(tags)
                     .views(post.getViews())

--- a/src/main/java/com/example/service/member/MemberService.java
+++ b/src/main/java/com/example/service/member/MemberService.java
@@ -3,10 +3,7 @@ package com.example.service.member;
 import com.example.api.ApiResult;
 import com.example.domain.member.Member;
 import com.example.domain.point.Point;
-import com.example.dto.request.AddPointRequest;
-import com.example.dto.request.ChangeEmailRequest;
-import com.example.dto.request.ChangePwdRequest;
-import com.example.dto.request.ChangeUsernameRequest;
+import com.example.dto.request.*;
 import com.example.dto.response.MemberInfoResponse;
 import com.example.exception.CustomException;
 import com.example.exception.ErrorCode;
@@ -108,6 +105,20 @@ public class MemberService {
         member.changeUsername(changeUsernameRequest.getNewUsername());
 
         return ApiResult.success("이름이 변경되었습니다.");
+    }
+
+    /*
+    프로필 이미지 변경
+     */
+    @Transactional
+    public ApiResult<?> changeProfileImage(ChangeProfileImageRequest changeProfileImageRequest, String userId) {
+        Member member = memberRepository.findByUserId(userId)
+                .orElseThrow(() -> new CustomException(ErrorCode.MEMBER_NOT_FOUND));
+
+        member.setProfile_path(changeProfileImageRequest.getProfileImagePathUrl());
+        memberRepository.save(member);
+
+        return ApiResult.success("프로필 이미지가 변경되었습니다");
     }
 
 }


### PR DESCRIPTION
## 👀 이슈

resolve #61

## 📌 개요

사용자가 자신의 프로필 이미지를 변경할 수 있는 기능을 추가했습니다. 

## 👩‍💻 작업 사항

- `ChangeProfileImageRequest` DTO를 생성하여 프로필 이미지 URL을 받습니다.
- `MemberService`에 `changeProfileImage` 메서드를 추가하여 사용자의 프로필 이미지를 변경합니다.
- `MemberController`에 프로필 이미지 변경 API 엔드포인트를 추가합니다.

## ✅ 참고 사항

