### PR TITLE
[feat]: member 테이블에 created_at 속성 추가 #63

### DIFF
--- a/src/main/java/com/example/BuddyApplication.java
+++ b/src/main/java/com/example/BuddyApplication.java
@@ -2,8 +2,10 @@ package com.example;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @SpringBootApplication
+@EnableJpaAuditing
 public class BuddyApplication {
 
     public static void main(String[] args) {

--- a/src/main/java/com/example/domain/member/Member.java
+++ b/src/main/java/com/example/domain/member/Member.java
@@ -3,7 +3,11 @@ package com.example.domain.member;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.NotBlank;
 import lombok.*;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 import org.springframework.security.crypto.password.PasswordEncoder;
+
+import java.time.LocalDateTime;
 
 /**
  * 회원 정보를 담고 있는 엔티티
@@ -14,6 +18,7 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
+@EntityListeners(AuditingEntityListener.class)
 public class Member {
 
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -35,6 +40,10 @@ public class Member {
 
     @Enumerated(EnumType.STRING)
     private MemberAuthority memberAuthority;
+
+    @CreatedDate
+    @Column(updatable = false)
+    private LocalDateTime createdAt;
 
 
     //== 비지니스 로직 ==//


### PR DESCRIPTION
## 👀 이슈

resolve #63

## 📌 개요

회원가입 일자를 수집하기 위해 `member` 테이블에 `created_at` 속성을 추가했습니다.

## 👩‍💻 작업 사항

- `member` 테이블에 `created_at` 속성을 추가했습니다.
- Spring Data JPA의 Auditing 기능을 사용하여 회원가입 시 `created_at` 속성에 현재 시간이 자동으로 저장되도록 설정했습니다.

## ✅ 참고 사항

없습니다.
