### PR TITLE
[fix] github 템플릿 내 Issue 게시글 Title lowerCase로 일괄 변경 #68

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.md
+++ b/.github/ISSUE_TEMPLATE/bug.md
@@ -1,9 +1,9 @@
 ---
-name: BUG
+name: bug
 about: 버그 수정
-title: "[BUG]"
-labels: "🐛 BUG"
-assignees: ""
+title: '[bug]'
+labels: 'bug'
+assignees: ''
 ---
 
 ## 🚨 문제 상황

--- a/.github/ISSUE_TEMPLATE/feat.md
+++ b/.github/ISSUE_TEMPLATE/feat.md
@@ -1,9 +1,9 @@
 ---
-name: FEAT
+name: feat
 about: 기능 추가
-title: "[FEAT]"
-labels: "⚙ FEAT"
-assignees: ""
+title: '[feat]'
+labels: 'feat'
+assignees: ''
 ---
 
 ## 📋 기능 추가 개요

--- a/.github/ISSUE_TEMPLATE/fix.md
+++ b/.github/ISSUE_TEMPLATE/fix.md
@@ -1,9 +1,9 @@
 ---
-name: FIX
+name: fix
 about: 기능 수정
-title: "[FIX]"
-labels: "🛠 FIX"
-assignees: ""
+title: '[fix]'
+labels: 'fix'
+assignees: ''
 ---
 
 ## 🧐 기능 수정 사유

--- a/.github/ISSUE_TEMPLATE/refactor.md
+++ b/.github/ISSUE_TEMPLATE/refactor.md
@@ -1,9 +1,9 @@
 ---
-name: REFACTOR
+name: refactor
 about: 코드 구조 재조정(개선)
-title: "[REFACTOR]"
-labels: "⛓ REFACTOR"
-assignees: ""
+title: '[refactor]'
+labels: 'refactor'
+assignees: ''
 ---
 
 ## 🧐 리팩토링 사유


### PR DESCRIPTION
## 👀 이슈

resolve #68 

## 📌 개요

기존에 사용하던 `github` 템플릿 내 Issue 게시글 생성 시 게시글 `Title` 이슈분류명에
해당하는 단어가 대문자로 구성되어 있었는데, 팀원 간 대소문자 작성에 대한 혼동이 발생하여
해당 문제를 개선하고자 이슈분류명에 해당하는 단어들을 소문자로 일괄적으로 변경하였습니다.

## 👩‍💻 작업 사항

- `bug.md`, `feat.md`, `fix.md`, `help.md`, `refactor.md` 파일 내 `title` 항목의 단어를 소문자로 일괄 변경

## ✅ 참고 사항

- 수정 후 Issue 게시글 생성 시 Title 상태
> `이슈분류명이 소문자로 자동 표시됨.

<img width="390" alt="Screenshot 2024-07-28 at 11 21 57 AM" src="https://github.com/user-attachments/assets/48cb7b25-c898-4b26-8dee-9ff00eefb0ef">