### PR TITLE
[feat] 회원의 구독 태그 목록 조회 #75

### DIFF
--- a/src/main/java/com/example/controller/subscribe/SubscribeController.java
+++ b/src/main/java/com/example/controller/subscribe/SubscribeController.java
@@ -31,4 +31,10 @@ public class SubscribeController {
     public ApiResult<?> unsubscribeTag(HttpServletRequest request, @PathVariable Long tagId) {
         return subscribeService.unsubscribeTag(request, tagId);
     }
+
+    @Operation(summary = "회원의 구독 태그 목록 조회", description = "")
+    @GetMapping("my-subscribed-tags")
+    public ApiResult<?> getSubscribedTags(HttpServletRequest request) {
+        return subscribeService.getSubscribedTags(request);
+    }
 }

--- a/src/main/java/com/example/dto/response/TagSubInfoResponse.java
+++ b/src/main/java/com/example/dto/response/TagSubInfoResponse.java
@@ -1,0 +1,15 @@
+package com.example.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@Builder
+@AllArgsConstructor
+public class TagSubInfoResponse {
+
+    private Long tagId;
+    private String tag;
+    private Boolean isReceiveNotification;
+}

--- a/src/main/java/com/example/exception/ErrorCode.java
+++ b/src/main/java/com/example/exception/ErrorCode.java
@@ -35,7 +35,7 @@ public enum ErrorCode {
     NOT_JOINED_PARTY(HttpStatus.NOT_FOUND, "가입한 파티가 없습니다."),
     PARTY_FULL(HttpStatus.NOT_FOUND, "이미 해당 파티의 정원이 모두 차있습니다."),
     POST_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 게시글이 없습니다."),
-    SUBSCRIPTION_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 게시글이 없습니다."),
+    SUBSCRIPTION_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 태그를 구독하고 있지 않습니다"),
 
     // 409 CONFLICT
     ALREADY_EXIST_USERID(HttpStatus.CONFLICT, "이미 존재하는 아이디입니다."),

--- a/src/main/java/com/example/repository/subscribe/TagSubRepository.java
+++ b/src/main/java/com/example/repository/subscribe/TagSubRepository.java
@@ -1,11 +1,15 @@
 package com.example.repository.subscribe;
 
+import com.example.domain.member.Member;
 import com.example.domain.subscribe.TagSub;
 import com.example.domain.subscribe.TagSubId;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface TagSubRepository extends JpaRepository<TagSub, TagSubId> {
     Optional<TagSub> findByMember_MemberIdAndTag_Id(Long memberId, Long tagId);
+
+    List<TagSub> findByMember_MemberId(Long memberId);
 }

--- a/src/main/java/com/example/service/subscribe/SubscribeService.java
+++ b/src/main/java/com/example/service/subscribe/SubscribeService.java
@@ -101,7 +101,6 @@ public class SubscribeService {
                         .build())
                 .collect(Collectors.toList());
 
-
         return ApiResult.success(tagResponses);
     }
 }


### PR DESCRIPTION
## 👀 이슈

resolve #75 

## 📌 개요

사용자가 자신이 구독한 태그 목록을 조회할 수 있도록 해당 기능을 추가했습니다.

## 👩‍💻 작업 사항

- HTTP 메서드 및 엔드포인트
: GET, /private/subscribe/my-subscribed-tags
- 사용자는 자신의 구독 태그 목록만 조회가 가능합니다.

## ✅ 참고 사항
첫번째 커밋 #78 오타나서 다시 커밋하였습니다.