### PR TITLE
[feat] 댓글 작성/수정/삭제 기능 추가

### DIFF
--- a/src/main/java/com/example/controller/community/CommentController.java
+++ b/src/main/java/com/example/controller/community/CommentController.java
@@ -1,0 +1,38 @@
+package com.example.controller.community;
+
+import com.example.api.ApiResult;
+import com.example.dto.request.CommentRequest;
+import com.example.service.community.CommentService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.bind.annotation.*;
+
+@Tag(name = "댓글 API")
+@Slf4j
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/private/posts")
+public class CommentController {
+
+    private final CommentService commentService;
+
+    @Operation(summary = "댓글 작성하기", description = "")
+    @PostMapping("/{postId}/comment")
+    public ApiResult<?> createComment(@PathVariable Long postId, @RequestBody CommentRequest request) {
+        return commentService.createComment(postId, request.getContent());
+    }
+
+    @Operation(summary = "댓글 삭제하기", description = "")
+    @DeleteMapping("/comments/{commentId}")
+    public ApiResult<?> deleteComment(@PathVariable Long commentId) {
+        return commentService.deleteComment(commentId);
+    }
+
+    @Operation(summary = "댓글 수정하기", description = "")
+    @PatchMapping("/comments/{commentId}")
+    public ApiResult<?> updateComment(@PathVariable Long commentId, @RequestBody CommentRequest request) {
+        return commentService.updateComment(commentId, request.getContent());
+    }
+}

--- a/src/main/java/com/example/controller/community/CommentController.java
+++ b/src/main/java/com/example/controller/community/CommentController.java
@@ -5,6 +5,7 @@ import com.example.dto.request.CommentRequest;
 import com.example.service.community.CommentService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.web.bind.annotation.*;
@@ -20,8 +21,8 @@ public class CommentController {
 
     @Operation(summary = "댓글 작성하기", description = "")
     @PostMapping("/{postId}/comment")
-    public ApiResult<?> createComment(@PathVariable Long postId, @RequestBody CommentRequest request) {
-        return commentService.createComment(postId, request.getContent());
+    public ApiResult<?> createComment(@PathVariable Long postId, HttpServletRequest request, @RequestBody CommentRequest commentRequest) {
+        return commentService.createComment(postId, request, commentRequest.getContent());
     }
 
     @Operation(summary = "댓글 삭제하기", description = "")
@@ -32,7 +33,7 @@ public class CommentController {
 
     @Operation(summary = "댓글 수정하기", description = "")
     @PatchMapping("/comments/{commentId}")
-    public ApiResult<?> updateComment(@PathVariable Long commentId, @RequestBody CommentRequest request) {
-        return commentService.updateComment(commentId, request.getContent());
+    public ApiResult<?> updateComment(@PathVariable Long commentId, @RequestBody CommentRequest commentRequest) {
+        return commentService.updateComment(commentId, commentRequest.getContent());
     }
 }

--- a/src/main/java/com/example/domain/community/Comment.java
+++ b/src/main/java/com/example/domain/community/Comment.java
@@ -1,0 +1,39 @@
+package com.example.domain.community;
+
+import com.example.domain.member.Member;
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Setter
+@Entity
+@NoArgsConstructor
+@EntityListeners(AuditingEntityListener.class)
+public class Comment {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "comment_id")
+    private Long id;
+
+    @ManyToOne
+    @JoinColumn(name = "member_id")
+    private Member member;
+
+    @ManyToOne
+    @JoinColumn(name = "post_id")
+    private Post post;
+
+    private String postContent;
+
+    private LocalDateTime createdTime;
+
+    @LastModifiedDate
+    private LocalDateTime modifiedTime;
+}

--- a/src/main/java/com/example/dto/request/CommentRequest.java
+++ b/src/main/java/com/example/dto/request/CommentRequest.java
@@ -1,0 +1,10 @@
+package com.example.dto.request;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class CommentRequest {
+    private String content;
+}

--- a/src/main/java/com/example/exception/ErrorCode.java
+++ b/src/main/java/com/example/exception/ErrorCode.java
@@ -13,9 +13,8 @@ public enum ErrorCode {
     PASSWORD_NOT_MATCH(HttpStatus.BAD_REQUEST, "기존 비밀번호가 일치하지 않습니다."),
     INVALID_REC_LIMIT(HttpStatus.BAD_REQUEST, "모집 인원은 0보다 커야 합니다."),
     EXCEEDS_MAX_MEMBER_NUM(HttpStatus.BAD_REQUEST, "모집 인원이 요금제의 최대 사용자 수를 초과할 수 없습니다."),
-    PARTY_ALREADY_STARTED(HttpStatus.BAD_REQUEST,"시작된 파티의 모집 인원은 변경할 수 없습니다."),
+    PARTY_ALREADY_STARTED(HttpStatus.BAD_REQUEST, "시작된 파티의 모집 인원은 변경할 수 없습니다."),
     INVALID_SERVICE_ID(HttpStatus.BAD_REQUEST, "존재하지 않는 서비스입니다."),
-
     LEADER_CANNOT_LEAVE_PARTY(HttpStatus.BAD_REQUEST, "파티장은 파티를 탈퇴할 수 없습니다."),
 
     // 401 UNAUTHORIZED
@@ -35,6 +34,7 @@ public enum ErrorCode {
     NOT_JOINED_PARTY(HttpStatus.NOT_FOUND, "가입한 파티가 없습니다."),
     PARTY_FULL(HttpStatus.NOT_FOUND, "이미 해당 파티의 정원이 모두 차있습니다."),
     POST_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 게시글이 없습니다."),
+    COMMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 댓글이 없습니다."),
     SUBSCRIPTION_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 태그를 구독하고 있지 않습니다"),
 
     // 409 CONFLICT
@@ -43,7 +43,7 @@ public enum ErrorCode {
     ALREADY_EXIST_USERNAME(HttpStatus.CONFLICT, "이미 존재하는 이름입니다."),
     ALREADY_JOINED_PARTY(HttpStatus.CONFLICT, "이미 파티에 가입 되어 있습니다."),
     ALREADY_SUBSCRIBED(HttpStatus.CONFLICT, "이미 해당 태그를 구독 중입니다."),
-    ALREADY_ON_NOTIFY(HttpStatus.CONFLICT, "이미 해당 태그에 대한 신규 게시글 알림이 커져있습니다."),
+    ALREADY_ON_NOTIFY(HttpStatus.CONFLICT, "이미 해당 태그에 대한 신규 게시글 알림이 켜져있습니다."),
     ALREADY_OFF_NOTIFY(HttpStatus.CONFLICT, "이미 해당 태그에 대한 신규 게시글 알림이 꺼져있습니다."),
     ALREADY_PAYMENT_KEY(HttpStatus.CONFLICT, "이미 존재하는 결제 키입니다.");
 

--- a/src/main/java/com/example/repository/community/CommentRepository.java
+++ b/src/main/java/com/example/repository/community/CommentRepository.java
@@ -1,0 +1,9 @@
+package com.example.repository.community;
+
+import com.example.domain.community.Comment;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface CommentRepository extends JpaRepository<Comment, Long> {
+}

--- a/src/main/java/com/example/service/community/CommentService.java
+++ b/src/main/java/com/example/service/community/CommentService.java
@@ -1,0 +1,65 @@
+package com.example.service.community;
+
+import com.example.api.ApiResult;
+import com.example.domain.community.Comment;
+import com.example.domain.community.Post;
+import com.example.exception.CustomException;
+import com.example.exception.ErrorCode;
+import com.example.repository.community.CommentRepository;
+import com.example.repository.community.PostRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+@Slf4j
+public class CommentService {
+
+    private final CommentRepository commentRepository;
+    private final PostRepository postRepository;
+
+    /*
+    댓글 작성
+    */
+    @Transactional
+    public ApiResult<?> createComment(Long postId, String content) {
+        Post post = postRepository.findById(postId)
+                .orElseThrow(() -> new CustomException(ErrorCode.POST_NOT_FOUND));
+        Comment comment = new Comment();
+        comment.setPost(post);
+        comment.setPostContent(content);
+        comment.setCreatedTime(LocalDateTime.now());
+        comment.setModifiedTime(LocalDateTime.now());
+        commentRepository.save(comment);
+        return ApiResult.success("댓글이 작성되었습니다.");
+    }
+
+    /*
+    댓글 삭제
+    */
+    @Transactional
+    public ApiResult<?> deleteComment(Long commentId) {
+        Comment comment = commentRepository.findById(commentId)
+                .orElseThrow(() -> new CustomException(ErrorCode.COMMENT_NOT_FOUND));
+        commentRepository.delete(comment);
+        return ApiResult.success("댓글이 삭제되었습니다.");
+    }
+
+    /*
+    댓글 수정
+    */
+    @Transactional
+    public ApiResult<?> updateComment(Long commentId, String content) {
+        Comment comment = commentRepository.findById(commentId)
+                .orElseThrow(() -> new CustomException(ErrorCode.COMMENT_NOT_FOUND));
+        comment.setPostContent(content);
+        comment.setModifiedTime(LocalDateTime.now());
+        commentRepository.save(comment);
+        return ApiResult.success("댓글이 수정되었습니다.");
+    }
+}


### PR DESCRIPTION
## 👀 이슈

resolve #79 

## 📌 개요

게시글에 대해 사용자가 댓글을 작성, 삭제, 수정할 수 있는 기능을 추가했습니다.

## 👩‍💻 작업 사항

- 댓글 작성 API 추가: POST, /private/posts/{postId}/comment
- 댓글 삭제 API 추가: DELETE, /private/comments/{commentId}
- 댓글 수정 API 추가: PATCH, /private/comments/{commentId}

## ✅ 참고 사항

없습니다.