### PR TITLE
[feat] '내가 쓴 커뮤니티 게시글 목록 조회' 기능에 댓글 수 추가 #89

### DIFF
--- a/src/main/java/com/example/domain/community/Post.java
+++ b/src/main/java/com/example/domain/community/Post.java
@@ -39,4 +39,7 @@ public class Post {
 
     @OneToMany(mappedBy = "post", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<Photo> photos = new ArrayList<>();
+
+    @OneToMany(mappedBy = "post", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<Comment> comments = new ArrayList<>();
 }

--- a/src/main/java/com/example/dto/response/MyPostResponse.java
+++ b/src/main/java/com/example/dto/response/MyPostResponse.java
@@ -20,6 +20,7 @@ public class MyPostResponse {
     private Author author;
     private List<String> tags;
     private int views;
+    private int commentCount;
 
     @Getter
     @Builder

--- a/src/main/java/com/example/repository/community/CommentRepository.java
+++ b/src/main/java/com/example/repository/community/CommentRepository.java
@@ -2,8 +2,7 @@ package com.example.repository.community;
 
 import com.example.domain.community.Comment;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.stereotype.Repository;
 
-@Repository
 public interface CommentRepository extends JpaRepository<Comment, Long> {
+    int countByPostId(Long postId);
 }

--- a/src/main/java/com/example/repository/community/ReplyRepository.java
+++ b/src/main/java/com/example/repository/community/ReplyRepository.java
@@ -2,6 +2,9 @@ package com.example.repository.community;
 
 import com.example.domain.community.Reply;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
 
+@Repository
 public interface ReplyRepository extends JpaRepository<Reply, Long> {
+    int countByCommentPostId(Long postId);
 }

--- a/src/main/java/com/example/service/community/CommunityService.java
+++ b/src/main/java/com/example/service/community/CommunityService.java
@@ -39,6 +39,7 @@ public class CommunityService {
     private final ServiceRepository serviceRepository;
     private final TokenProvider tokenProvider;
     private final CommentRepository commentRepository;
+    private final ReplyRepository replyRepository;
 
     // 토큰에서 사용자 ID 추출
     public String getUserIdFromToken(HttpServletRequest request) {
@@ -219,6 +220,9 @@ public class CommunityService {
                     .collect(Collectors.toList());
 
             int commentCount = commentRepository.countByPostId(post.getId());
+            int replyCount = replyRepository.countByCommentPostId(post.getId());
+            int totalCommentCount = commentCount + replyCount;
+
 
             return MyPostResponse.builder()
                     .postId(post.getId())
@@ -233,7 +237,7 @@ public class CommunityService {
                             .build())
                     .tags(tags)
                     .views(post.getViews())
-                    .commentCount(commentCount)
+                    .commentCount(totalCommentCount)
                     .build();
         }).collect(Collectors.toList());
 

--- a/src/main/java/com/example/service/community/CommunityService.java
+++ b/src/main/java/com/example/service/community/CommunityService.java
@@ -38,6 +38,7 @@ public class CommunityService {
     private final MemberRepository memberRepository;
     private final ServiceRepository serviceRepository;
     private final TokenProvider tokenProvider;
+    private final CommentRepository commentRepository;
 
     // 토큰에서 사용자 ID 추출
     public String getUserIdFromToken(HttpServletRequest request) {
@@ -217,6 +218,8 @@ public class CommunityService {
                     .map(postTag -> postTag.getTag().getTagName())
                     .collect(Collectors.toList());
 
+            int commentCount = commentRepository.countByPostId(post.getId());
+
             return MyPostResponse.builder()
                     .postId(post.getId())
                     .title(post.getTitle())
@@ -230,6 +233,7 @@ public class CommunityService {
                             .build())
                     .tags(tags)
                     .views(post.getViews())
+                    .commentCount(commentCount)
                     .build();
         }).collect(Collectors.toList());
 


### PR DESCRIPTION
## 👀 이슈

resolve #89

## 📌 개요

'내가 쓴 커뮤니티 게시글 목록 조회' 기능에 댓글 수를 추가하여 해당 값을 반환 하고자 합니다.

## 👩‍💻 작업 사항

- `MyPostResponse` DTO에 `commentCount` 필드 추가
- `Post` 엔티티와 `Comment` 엔티티 간의 관계를 설정

## ✅ 참고 사항

없습니다
