### PR TITLE
[feat] ‘내가 쓴 커뮤니티 게시글 목록 조회’ 기능에 likecount 반환값 추가 #93

### DIFF
--- a/src/main/java/com/example/controller/community/PostLikeController.java
+++ b/src/main/java/com/example/controller/community/PostLikeController.java
@@ -1,0 +1,33 @@
+package com.example.controller.community;
+
+import com.example.api.ApiResult;
+import com.example.service.community.PostLikeService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@Tag(name = "게시글 좋아요 API")
+@Slf4j
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/private/posts")
+public class PostLikeController {
+
+    private final PostLikeService postLikeService;
+
+    @Operation(summary = "게시글 좋아요 누르기", description = "")
+    @PostMapping("/{postId}/like")
+    public ApiResult<String> likePost(@PathVariable Long postId, HttpServletRequest request) {
+        return postLikeService.likePost(request, postId);
+    }
+
+    @Operation(summary = "게시글 좋아요 취소하기", description = "")
+    @DeleteMapping("/{postId}/like")
+    public ApiResult<String> unlikePost(@PathVariable Long postId, HttpServletRequest request) {
+        return postLikeService.unlikePost(request, postId);
+    }
+}

--- a/src/main/java/com/example/domain/community/Post.java
+++ b/src/main/java/com/example/domain/community/Post.java
@@ -39,4 +39,7 @@ public class Post {
 
     @OneToMany(mappedBy = "post", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<Photo> photos = new ArrayList<>();
+
+    @OneToMany(mappedBy = "post", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<Comment> comments = new ArrayList<>();
 }

--- a/src/main/java/com/example/domain/community/PostLike.java
+++ b/src/main/java/com/example/domain/community/PostLike.java
@@ -1,0 +1,27 @@
+package com.example.domain.community;
+
+import com.example.domain.member.Member;
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Entity
+@Table(name = "post_like")
+@Getter
+@Setter
+@NoArgsConstructor
+public class PostLike {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "post_like_id")
+    private Long id;
+
+    @ManyToOne
+    @JoinColumn(name = "member_id")
+    private Member member;
+
+    @ManyToOne
+    @JoinColumn(name = "post_id")
+    private Post post;
+}

--- a/src/main/java/com/example/dto/response/MyPostResponse.java
+++ b/src/main/java/com/example/dto/response/MyPostResponse.java
@@ -20,6 +20,7 @@ public class MyPostResponse {
     private Author author;
     private List<String> tags;
     private int views;
+    private int commentCount;
 
     @Getter
     @Builder

--- a/src/main/java/com/example/dto/response/MyPostResponse.java
+++ b/src/main/java/com/example/dto/response/MyPostResponse.java
@@ -21,6 +21,7 @@ public class MyPostResponse {
     private List<String> tags;
     private int views;
     private int commentCount;
+    private int likeCount;
 
     @Getter
     @Builder

--- a/src/main/java/com/example/exception/ErrorCode.java
+++ b/src/main/java/com/example/exception/ErrorCode.java
@@ -16,6 +16,8 @@ public enum ErrorCode {
     PARTY_ALREADY_STARTED(HttpStatus.BAD_REQUEST, "시작된 파티의 모집 인원은 변경할 수 없습니다."),
     INVALID_SERVICE_ID(HttpStatus.BAD_REQUEST, "존재하지 않는 서비스입니다."),
     LEADER_CANNOT_LEAVE_PARTY(HttpStatus.BAD_REQUEST, "파티장은 파티를 탈퇴할 수 없습니다."),
+    NOT_LIKED_YET(HttpStatus.BAD_REQUEST, "아직 좋아요를 누르지 않은 게시글입니다."),
+
 
     // 401 UNAUTHORIZED
     UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "인증 정보가 없습니다. 다시 로그인 하세요"),
@@ -46,6 +48,7 @@ public enum ErrorCode {
     ALREADY_SUBSCRIBED(HttpStatus.CONFLICT, "이미 해당 태그를 구독 중입니다."),
     ALREADY_ON_NOTIFY(HttpStatus.CONFLICT, "이미 해당 태그에 대한 신규 게시글 알림이 켜져있습니다."),
     ALREADY_OFF_NOTIFY(HttpStatus.CONFLICT, "이미 해당 태그에 대한 신규 게시글 알림이 꺼져있습니다."),
+    ALREADY_LIKED(HttpStatus.CONFLICT, "이미 좋아요를 누른 게시글입니다."),
     ALREADY_PAYMENT_KEY(HttpStatus.CONFLICT, "이미 존재하는 결제 키입니다.");
 
     private final HttpStatus httpStatus;

--- a/src/main/java/com/example/repository/community/CommentRepository.java
+++ b/src/main/java/com/example/repository/community/CommentRepository.java
@@ -2,8 +2,7 @@ package com.example.repository.community;
 
 import com.example.domain.community.Comment;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.stereotype.Repository;
 
-@Repository
 public interface CommentRepository extends JpaRepository<Comment, Long> {
+    int countByPostId(Long postId);
 }

--- a/src/main/java/com/example/repository/community/PostLikeRepository.java
+++ b/src/main/java/com/example/repository/community/PostLikeRepository.java
@@ -1,0 +1,12 @@
+package com.example.repository.community;
+
+import com.example.domain.community.PostLike;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface PostLikeRepository extends JpaRepository<PostLike, Long> {
+    boolean existsByMemberMemberIdAndPostId(Long memberId, Long postId);
+
+    PostLike findByMemberMemberIdAndPostId(Long memberId, Long postId);
+}

--- a/src/main/java/com/example/repository/community/PostLikeRepository.java
+++ b/src/main/java/com/example/repository/community/PostLikeRepository.java
@@ -9,4 +9,5 @@ public interface PostLikeRepository extends JpaRepository<PostLike, Long> {
     boolean existsByMemberMemberIdAndPostId(Long memberId, Long postId);
 
     PostLike findByMemberMemberIdAndPostId(Long memberId, Long postId);
+    int countByPostId(Long postId);
 }

--- a/src/main/java/com/example/repository/community/ReplyRepository.java
+++ b/src/main/java/com/example/repository/community/ReplyRepository.java
@@ -2,6 +2,9 @@ package com.example.repository.community;
 
 import com.example.domain.community.Reply;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
 
+@Repository
 public interface ReplyRepository extends JpaRepository<Reply, Long> {
+    int countByCommentPostId(Long postId);
 }

--- a/src/main/java/com/example/service/community/CommunityService.java
+++ b/src/main/java/com/example/service/community/CommunityService.java
@@ -39,6 +39,7 @@ public class CommunityService {
     private final ServiceRepository serviceRepository;
     private final TokenProvider tokenProvider;
     private final CommentRepository commentRepository;
+    private final ReplyRepository replyRepository;
 
     // 토큰에서 사용자 ID 추출
     public String getUserIdFromToken(HttpServletRequest request) {
@@ -219,6 +220,9 @@ public class CommunityService {
                     .collect(Collectors.toList());
 
             int commentCount = commentRepository.countByPostId(post.getId());
+            int replyCount = replyRepository.countByCommentPostId(post.getId());
+            int totalCommentCount = commentCount + replyCount;
+
 
             return MyPostResponse.builder()
                     .postId(post.getId())
@@ -233,7 +237,7 @@ public class CommunityService {
                             .build())
                     .tags(tags)
                     .views(post.getViews())
-                    .commentCount(commentCount)
+                    .commentCount(totalCommentCount)
                     .build();
         }).collect(Collectors.toList());
 

--- a/src/main/java/com/example/service/community/CommunityService.java
+++ b/src/main/java/com/example/service/community/CommunityService.java
@@ -38,6 +38,7 @@ public class CommunityService {
     private final MemberRepository memberRepository;
     private final ServiceRepository serviceRepository;
     private final TokenProvider tokenProvider;
+    private final CommentRepository commentRepository;
 
     // 토큰에서 사용자 ID 추출
     public String getUserIdFromToken(HttpServletRequest request) {
@@ -217,6 +218,8 @@ public class CommunityService {
                     .map(postTag -> postTag.getTag().getTagName())
                     .collect(Collectors.toList());
 
+            int commentCount = commentRepository.countByPostId(post.getId());
+
             return MyPostResponse.builder()
                     .postId(post.getId())
                     .title(post.getTitle())
@@ -230,6 +233,7 @@ public class CommunityService {
                             .build())
                     .tags(tags)
                     .views(post.getViews())
+                    .commentCount(commentCount)
                     .build();
         }).collect(Collectors.toList());
 

--- a/src/main/java/com/example/service/community/CommunityService.java
+++ b/src/main/java/com/example/service/community/CommunityService.java
@@ -40,6 +40,7 @@ public class CommunityService {
     private final TokenProvider tokenProvider;
     private final CommentRepository commentRepository;
     private final ReplyRepository replyRepository;
+    private final PostLikeRepository postLikeRepository;
 
     // 토큰에서 사용자 ID 추출
     public String getUserIdFromToken(HttpServletRequest request) {
@@ -222,6 +223,7 @@ public class CommunityService {
             int commentCount = commentRepository.countByPostId(post.getId());
             int replyCount = replyRepository.countByCommentPostId(post.getId());
             int totalCommentCount = commentCount + replyCount;
+            int likeCount = postLikeRepository.countByPostId(post.getId());
 
 
             return MyPostResponse.builder()
@@ -238,6 +240,7 @@ public class CommunityService {
                     .tags(tags)
                     .views(post.getViews())
                     .commentCount(totalCommentCount)
+                    .likeCount(likeCount)
                     .build();
         }).collect(Collectors.toList());
 

--- a/src/main/java/com/example/service/community/PostLikeService.java
+++ b/src/main/java/com/example/service/community/PostLikeService.java
@@ -1,0 +1,74 @@
+package com.example.service.community;
+
+import com.example.api.ApiResult;
+import com.example.config.jwt.TokenProvider;
+import com.example.domain.community.Post;
+import com.example.domain.community.PostLike;
+import com.example.domain.member.Member;
+import com.example.exception.CustomException;
+import com.example.exception.ErrorCode;
+import com.example.repository.community.PostLikeRepository;
+import com.example.repository.community.PostRepository;
+import com.example.repository.member.MemberRepository;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.Authentication;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class PostLikeService {
+    private final PostLikeRepository postLikeRepository;
+    private final PostRepository postRepository;
+    private final MemberRepository memberRepository;
+    private final TokenProvider tokenProvider;
+
+    public String getUserIdFromToken(HttpServletRequest request) {
+        Authentication authentication = tokenProvider.getAuthentication(tokenProvider.resolveToken(request));
+        return authentication.getName();
+    }
+
+    /*
+    게시글 좋아요 누르기
+     */
+    @Transactional
+    public ApiResult<String> likePost(HttpServletRequest request, Long postId) {
+        String userId = getUserIdFromToken(request);
+        Member member = memberRepository.findByUserId(userId)
+                .orElseThrow(() -> new CustomException(ErrorCode.MEMBER_NOT_FOUND));
+
+        if (postLikeRepository.existsByMemberMemberIdAndPostId(member.getMemberId(), postId)) {
+            throw new CustomException(ErrorCode.ALREADY_LIKED);
+        }
+
+        Post post = postRepository.findById(postId)
+                .orElseThrow(() -> new CustomException(ErrorCode.POST_NOT_FOUND));
+
+        PostLike postLike = new PostLike();
+        postLike.setPost(post);
+        postLike.setMember(member);
+
+        postLikeRepository.save(postLike);
+        return ApiResult.success("좋아요");
+    }
+
+    /*
+    게시글 좋아요 취소하기
+     */
+    @Transactional
+    public ApiResult<String> unlikePost(HttpServletRequest request, Long postId) {
+        String userId = getUserIdFromToken(request);
+        Member member = memberRepository.findByUserId(userId)
+                .orElseThrow(() -> new CustomException(ErrorCode.MEMBER_NOT_FOUND));
+
+        if (!postLikeRepository.existsByMemberMemberIdAndPostId(member.getMemberId(), postId)) {
+            throw new CustomException(ErrorCode.NOT_LIKED_YET);
+        }
+
+        PostLike postLike = postLikeRepository.findByMemberMemberIdAndPostId(member.getMemberId(), postId);
+        postLikeRepository.delete(postLike);
+
+        return ApiResult.success("좋아요 취소");
+    }
+}


### PR DESCRIPTION
## 👀 이슈

resolve #93

## 📌 개요

'내가 쓴 커뮤니티 게시글 목록 조회' 기능에 likecount를 추가하여 해당 값을 반환하고자 합니다.

## 👩‍💻 작업 사항

- Post 엔티티와  PostLike 엔티티 간의 관계를 설정합니다.
- 게시글 조회 시 좋아요 수를 포함하도록 합니다.

## ✅ 참고 사항

없습니다.
