### PR TITLE
[fix] API 엔드포인트 및 응답 바디 수정 #95

### DIFF
--- a/src/main/java/com/example/controller/community/CommunityController.java
+++ b/src/main/java/com/example/controller/community/CommunityController.java
@@ -42,7 +42,7 @@ public class CommunityController {
     }
 
     @Operation(summary = "내가 쓴 커뮤니티 게시글 목록 조회", description = "")
-    @GetMapping("/my-posts")
+    @GetMapping("/posts/my")
     public ApiResult<List<MyPostResponse>> getMyCommunityPosts(HttpServletRequest request) {
         return communityService.getMyCommunityPosts(request);
     }

--- a/src/main/java/com/example/controller/party/PartyController.java
+++ b/src/main/java/com/example/controller/party/PartyController.java
@@ -70,7 +70,7 @@ public class PartyController {
     /*
     나의 파티 목록 조회
      */
-    @GetMapping("/private/party/my-party")
+    @GetMapping("/private/party/my")
     @Operation(summary = "나의 파티 목록 조회", description = "")
     public ApiResult<?> getMyParties(HttpServletRequest request) {
         return partyService.getMyParties(request);

--- a/src/main/java/com/example/controller/subscribe/SubscribeController.java
+++ b/src/main/java/com/example/controller/subscribe/SubscribeController.java
@@ -21,19 +21,19 @@ public class SubscribeController {
 
 
     @Operation(summary = "태그 구독하기", description = "")
-    @PostMapping("tag/{tagId}")
+    @PostMapping("/tag/{tagId}")
     public ApiResult<?> subscribeTag(HttpServletRequest request, @PathVariable Long tagId) {
         return subscribeService.subscribeTag(request, tagId);
     }
 
     @Operation(summary = "태그 구독 취소하기", description = "")
-    @DeleteMapping("tag/{tagId}")
+    @DeleteMapping("/tag/{tagId}")
     public ApiResult<?> unsubscribeTag(HttpServletRequest request, @PathVariable Long tagId) {
         return subscribeService.unsubscribeTag(request, tagId);
     }
 
     @Operation(summary = "회원의 구독 태그 목록 조회", description = "")
-    @GetMapping("my-subscribed-tags")
+    @GetMapping("/my/subscribed-tags")
     public ApiResult<?> getSubscribedTags(HttpServletRequest request) {
         return subscribeService.getSubscribedTags(request);
     }

--- a/src/main/java/com/example/dto/response/TagSubInfoResponse.java
+++ b/src/main/java/com/example/dto/response/TagSubInfoResponse.java
@@ -8,8 +8,8 @@ import lombok.Data;
 @Builder
 @AllArgsConstructor
 public class TagSubInfoResponse {
-
     private Long tagId;
     private String tag;
     private Boolean isReceiveNotification;
+    private Long postCount;
 }

--- a/src/main/java/com/example/repository/community/PostRepository.java
+++ b/src/main/java/com/example/repository/community/PostRepository.java
@@ -1,10 +1,17 @@
 package com.example.repository.community;
 
 import com.example.domain.community.Post;
+import io.lettuce.core.dynamic.annotation.Param;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 import java.util.List;
 
 public interface PostRepository extends JpaRepository<Post, Long> {
     List<Post> findByMemberId(Long memberId);
+
+    @Query("SELECT COUNT(p) FROM PostTag p WHERE p.tag.id = :tagId")
+    Long countPostsByTagId(@Param("tagId") Long tagId);
+
+
 }

--- a/src/main/java/com/example/service/subscribe/SubscribeService.java
+++ b/src/main/java/com/example/service/subscribe/SubscribeService.java
@@ -8,6 +8,7 @@ import com.example.domain.subscribe.TagSub;
 import com.example.dto.response.TagSubInfoResponse;
 import com.example.exception.CustomException;
 import com.example.exception.ErrorCode;
+import com.example.repository.community.PostRepository;
 import com.example.repository.community.TagRepository;
 import com.example.repository.member.MemberRepository;
 import com.example.repository.subscribe.TagSubRepository;
@@ -31,6 +32,7 @@ public class SubscribeService {
     private final MemberRepository memberRepository;
     private final TagRepository tagRepository;
     private final TagSubRepository tagSubRepository;
+    private final PostRepository postRepository;
     private final TokenProvider tokenProvider;
 
     public String getUserIdFromToken(HttpServletRequest request) {
@@ -98,6 +100,7 @@ public class SubscribeService {
                         .tagId(tagSub.getTag().getId())
                         .tag(tagSub.getTag().getTagName())
                         .isReceiveNotification(tagSub.getSubNotify())
+                        .postCount(postRepository.countPostsByTagId(tagSub.getTag().getId()))
                         .build())
                 .collect(Collectors.toList());
 


### PR DESCRIPTION
## 👀 이슈

resolve #95

## 📌 개요

API 엔드포인트 응답 바디 수정

## 👩‍💻 작업 사항

[엔드포인트]
- 내가 쓴 커뮤니티 게시글 목록 조회 API 엔드포인트 수정
 : /private/community/posts/my

- 회원의 구독 태그 목록 조회 API 엔드포인트 수정
 : /private/subscribe/my/subscribed-tags

- 나의 파티 목록 조회 API 엔드포인트 수정
 : /private/party/my

[응답 바디]
- 회원의 구독 태그 목록 조회 
 : API 응답 바디에 postCount(해당 태그가 사용된 모든 게시글 수) 포함

## ✅ 참고 사항

공유할 내용 및 관련 스크린샷 등을 넣어 주세요
