### PR TITLE
[feat] 추천/연관 검색 태그 목록 정보 조회 기능 추가 #98

### DIFF
--- a/src/main/java/com/example/controller/community/CommunityController.java
+++ b/src/main/java/com/example/controller/community/CommunityController.java
@@ -30,20 +30,40 @@ public class CommunityController {
     }
 
     @Operation(summary = "커뮤니티 게시글 수정하기", description = "")
-    @PutMapping("/{postId}")
+    @PutMapping("/private/community/{postId}")
     public ApiResult<?> updatePost(@PathVariable Long postId, @RequestBody UpdatePostRequest updatePostRequest, HttpServletRequest request) {
         return communityService.updatePost(postId, updatePostRequest, request);
     }
 
     @Operation(summary = "커뮤니티 게시글 삭제하기", description = "")
-    @DeleteMapping("/{postId}")
+    @DeleteMapping("/private/community/{postId}")
     public ApiResult<?> deletePost(@PathVariable Long postId, HttpServletRequest request) {
         return communityService.deletePost(postId, request);
     }
 
     @Operation(summary = "내가 쓴 커뮤니티 게시글 목록 조회", description = "")
-    @GetMapping("/posts/my")
+    @GetMapping("/private/community/posts/my")
     public ApiResult<List<MyPostResponse>> getMyCommunityPosts(HttpServletRequest request) {
         return communityService.getMyCommunityPosts(request);
     }
+
+//    @Operation(summary = "태그 기반 커뮤니티 게시글 목록 정보 조회", description = "")
+//    @GetMapping("/public/community/posts")
+//    public ApiResult<?> getPostsByTag(@RequestParam String tag, @RequestParam int limit) {
+//        return communityService.getPostsByTag(tag, limit);
+//    }
+
+    @Operation(summary = "추천 태그 목록 정보 조회", description = "태그 등록 수가 가장 높은 상위 10개의 태그 목록 정보를 조회한다.")
+    @GetMapping("/public/community/recommendation-tags")
+    public ApiResult<?> getTop10Tags() {
+        return communityService.getTop10Tags();
+    }
+
+    @Operation(summary = "연관 검색 태그 목록 정보 조회", description = "특정 검색어를 포함하는 태그 목록 정보를 조회한다.")
+    @GetMapping("/public/community/search")
+    public ApiResult<?> getRelatedTags(@RequestParam String query) {
+        return communityService.getRelatedTags(query);
+    }
+
+
 }

--- a/src/main/java/com/example/controller/subscribe/SubscribeController.java
+++ b/src/main/java/com/example/controller/subscribe/SubscribeController.java
@@ -39,13 +39,13 @@ public class SubscribeController {
     }
 
     @Operation(summary = "태그 신규 게시글 알림 받기", description = "")
-    @PostMapping("/tags//{tagId}/notification")
+    @PostMapping("/tags/{tagId}/notification")
     public ApiResult<?> enableTagNotification(HttpServletRequest request, @PathVariable Long tagId) {
         return subscribeService.enableTagNotification(request, tagId);
     }
 
     @Operation(summary = "태그 신규 게시글 알림 끄기", description = "")
-    @DeleteMapping("/tags//{tagId}/notification")
+    @DeleteMapping("/tags/{tagId}/notification")
     public ApiResult<?> disableTagNotification(HttpServletRequest request, @PathVariable Long tagId) {
         return subscribeService.disableTagNotification(request, tagId);
     }

--- a/src/main/java/com/example/controller/subscribe/SubscribeController.java
+++ b/src/main/java/com/example/controller/subscribe/SubscribeController.java
@@ -21,13 +21,13 @@ public class SubscribeController {
 
 
     @Operation(summary = "태그 구독하기", description = "")
-    @PostMapping("/tag/{tagId}")
+    @PostMapping("/tags/{tagId}")
     public ApiResult<?> subscribeTag(HttpServletRequest request, @PathVariable Long tagId) {
         return subscribeService.subscribeTag(request, tagId);
     }
 
     @Operation(summary = "태그 구독 취소하기", description = "")
-    @DeleteMapping("/tag/{tagId}")
+    @DeleteMapping("/tags//{tagId}")
     public ApiResult<?> unsubscribeTag(HttpServletRequest request, @PathVariable Long tagId) {
         return subscribeService.unsubscribeTag(request, tagId);
     }
@@ -39,13 +39,13 @@ public class SubscribeController {
     }
 
     @Operation(summary = "태그 신규 게시글 알림 받기", description = "")
-    @PostMapping("/{tagId}/notification")
+    @PostMapping("/tags//{tagId}/notification")
     public ApiResult<?> enableTagNotification(HttpServletRequest request, @PathVariable Long tagId) {
         return subscribeService.enableTagNotification(request, tagId);
     }
 
     @Operation(summary = "태그 신규 게시글 알림 끄기", description = "")
-    @DeleteMapping("/{tagId}/notification")
+    @DeleteMapping("/tags//{tagId}/notification")
     public ApiResult<?> disableTagNotification(HttpServletRequest request, @PathVariable Long tagId) {
         return subscribeService.disableTagNotification(request, tagId);
     }

--- a/src/main/java/com/example/dto/response/PostsByTagInfoResponse.java
+++ b/src/main/java/com/example/dto/response/PostsByTagInfoResponse.java
@@ -1,0 +1,74 @@
+package com.example.dto.response;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Getter
+@Setter
+@Builder
+public class PostsByTagInfoResponse {
+    private Long postId;
+    private String title;
+    private String content;
+    private LocalDateTime createdAt;
+//    private LocalDateTime modifiedAt;
+    private List<String> postImagePathUrls;
+    private AuthorDto author;
+    private List<TagsDto> tags;
+    private int views;
+    private List<ServiceDto> services;
+    private List<CommentDto> comments;
+    private int likeCount;
+
+    @Getter
+    @Setter
+    @Builder
+    public static class AuthorDto {
+        private Long memberId;
+        private String username;
+        private String profileImagePathUrl;
+    }
+
+    @Getter
+    @Setter
+    @Builder
+    public static class TagsDto {
+        private Long tagId;
+        private String tag;
+    }
+
+    @Getter
+    @Setter
+    @Builder
+    public static class ServiceDto {
+        private Long serviceId;
+        private List<Long> planIds;
+        private String name;
+        private String url;
+    }
+
+    @Getter
+    @Setter
+    @Builder
+    public static class CommentDto {
+        private String comment;
+        private int likeCount;
+        private LocalDateTime createdAt;
+        private AuthorDto writer;
+        private List<ReplyDto> replies;
+
+        @Getter
+        @Setter
+        @Builder
+        public static class ReplyDto {
+            private String reply;
+            private int likeCount;
+            private LocalDateTime createdAt;
+            private AuthorDto writer;
+        }
+    }
+}

--- a/src/main/java/com/example/dto/response/TagInfoResponse.java
+++ b/src/main/java/com/example/dto/response/TagInfoResponse.java
@@ -1,5 +1,4 @@
 package com.example.dto.response;
-
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -7,9 +6,8 @@ import lombok.Data;
 @Data
 @Builder
 @AllArgsConstructor
-public class TagSubInfoResponse {
+public class TagInfoResponse {
     private Long tagId;
-    private String tags;
-    private Boolean isReceiveNotification;
+    private String tagName;
     private Long postCount;
 }

--- a/src/main/java/com/example/repository/community/PostRepository.java
+++ b/src/main/java/com/example/repository/community/PostRepository.java
@@ -5,6 +5,7 @@ import io.lettuce.core.dynamic.annotation.Param;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 
+import java.awt.print.Pageable;
 import java.util.List;
 
 public interface PostRepository extends JpaRepository<Post, Long> {
@@ -13,5 +14,7 @@ public interface PostRepository extends JpaRepository<Post, Long> {
     @Query("SELECT COUNT(p) FROM PostTag p WHERE p.tag.id = :tagId")
     Long countPostsByTagId(@Param("tagId") Long tagId);
 
+//    @Query("SELECT p FROM Post p JOIN p.tags t WHERE t.tagName = :tag ORDER BY p.createdAt DESC")
+//    List<Post> findByTagName(@Param("tag") String tag, Pageable pageable);
 
 }

--- a/src/main/java/com/example/repository/community/PostTagRepository.java
+++ b/src/main/java/com/example/repository/community/PostTagRepository.java
@@ -14,18 +14,10 @@ public interface PostTagRepository extends JpaRepository<PostTag, Long> {
 //    List<Tag> findTop10ByOrderByTagCountDesc();4
 
     //태그 등록 수가 가장 높은 상위 태그 목록 조회
-    @Query("SELECT pt.tag, COUNT(pt.post) FROM PostTag pt GROUP BY pt.tag ORDER BY COUNT(pt.post) DE" +
-            "SC")
+    @Query("SELECT pt.tag, COUNT(pt.post) FROM PostTag pt GROUP BY pt.tag ORDER BY COUNT(pt.post) DESC")
     List<Object[]> findTopTagsWithPostCount();
 
-    //특정 검색어를 포함하는 태그와 해당 태그에 대한 게시물 개수 조회
-    @Query(value = "SELECT t.tag_id, t.tag_name, COUNT(pt.tag_id) " +
-            "FROM post_tags pt " +
-            "JOIN tag t ON pt.tag_id = t.tag_id " +
-            "WHERE t.tag_name LIKE %:query% COLLATE utf8mb4_unicode_ci " +
-            "GROUP BY t.tag_id, t.tag_name " +
-            "ORDER BY COUNT(pt.tag_id) DESC", nativeQuery = true)
+    //특정 검색어를 포함하는 태그와 해당 태그에 대한 게시물 개수ㄴ 조회
+    @Query("SELECT pt.tag, COUNT(pt.post) FROM PostTag pt WHERE pt.tag.tagName LIKE %:query% GROUP BY pt.tag ORDER BY COUNT(pt.post) DESC")
     List<Object[]> findRelatedTagsWithPostCount(@Param("query") String query);
-
-
 }

--- a/src/main/java/com/example/repository/community/PostTagRepository.java
+++ b/src/main/java/com/example/repository/community/PostTagRepository.java
@@ -2,10 +2,22 @@ package com.example.repository.community;
 
 import com.example.domain.community.Post;
 import com.example.domain.community.PostTag;
+import com.example.domain.community.Tag;
+import io.lettuce.core.dynamic.annotation.Param;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 import java.util.List;
 
 public interface PostTagRepository extends JpaRepository<PostTag, Long> {
     List<PostTag> findByPost(Post post);
+//    List<Tag> findTop10ByOrderByTagCountDesc();4
+
+    //태그 등록 수가 가장 높은 상위 태그 목록 조회
+    @Query("SELECT pt.tag, COUNT(pt.post) FROM PostTag pt GROUP BY pt.tag ORDER BY COUNT(pt.post) DESC")
+    List<Object[]> findTopTagsWithPostCount();
+
+    //특정 검색어를 포함하는 태그와 해당 태그에 대한 게시물 개수ㄴ 조회
+    @Query("SELECT pt.tag, COUNT(pt.post) FROM PostTag pt WHERE pt.tag.tagName LIKE %:query% GROUP BY pt.tag ORDER BY COUNT(pt.post) DESC")
+    List<Object[]> findRelatedTagsWithPostCount(@Param("query") String query);
 }

--- a/src/main/java/com/example/repository/community/PostTagRepository.java
+++ b/src/main/java/com/example/repository/community/PostTagRepository.java
@@ -14,10 +14,18 @@ public interface PostTagRepository extends JpaRepository<PostTag, Long> {
 //    List<Tag> findTop10ByOrderByTagCountDesc();4
 
     //태그 등록 수가 가장 높은 상위 태그 목록 조회
-    @Query("SELECT pt.tag, COUNT(pt.post) FROM PostTag pt GROUP BY pt.tag ORDER BY COUNT(pt.post) DESC")
+    @Query("SELECT pt.tag, COUNT(pt.post) FROM PostTag pt GROUP BY pt.tag ORDER BY COUNT(pt.post) DE" +
+            "SC")
     List<Object[]> findTopTagsWithPostCount();
 
-    //특정 검색어를 포함하는 태그와 해당 태그에 대한 게시물 개수ㄴ 조회
-    @Query("SELECT pt.tag, COUNT(pt.post) FROM PostTag pt WHERE pt.tag.tagName LIKE %:query% GROUP BY pt.tag ORDER BY COUNT(pt.post) DESC")
+    //특정 검색어를 포함하는 태그와 해당 태그에 대한 게시물 개수 조회
+    @Query(value = "SELECT t.tag_id, t.tag_name, COUNT(pt.tag_id) " +
+            "FROM post_tags pt " +
+            "JOIN tag t ON pt.tag_id = t.tag_id " +
+            "WHERE t.tag_name LIKE %:query% COLLATE utf8mb4_unicode_ci " +
+            "GROUP BY t.tag_id, t.tag_name " +
+            "ORDER BY COUNT(pt.tag_id) DESC", nativeQuery = true)
     List<Object[]> findRelatedTagsWithPostCount(@Param("query") String query);
+
+
 }

--- a/src/main/java/com/example/service/community/CommunityService.java
+++ b/src/main/java/com/example/service/community/CommunityService.java
@@ -363,12 +363,11 @@ public class CommunityService {
 
         List<TagInfoResponse> relatedTagsResponse = tagPostCounts.stream()
                 .map(result -> {
-                    Long tagId = ((Number) result[0]).longValue();  // tag_id
-                    String tagName = (String) result[1];  // tag_name
-                    Long postCount = ((Number) result[2]).longValue();  // COUNT(pt.tag_id)
+                    Tag tag = (Tag) result[0];
+                    Long postCount = (Long) result[1];
                     return TagInfoResponse.builder()
-                            .tagId(tagId)  // tagId 설정
-                            .tagName(tagName)  // tagName 설정
+                            .tagId(tag.getId())
+                            .tagName(tag.getTagName())
                             .postCount(postCount)
                             .build();
                 })

--- a/src/main/java/com/example/service/community/CommunityService.java
+++ b/src/main/java/com/example/service/community/CommunityService.java
@@ -363,11 +363,12 @@ public class CommunityService {
 
         List<TagInfoResponse> relatedTagsResponse = tagPostCounts.stream()
                 .map(result -> {
-                    Tag tag = (Tag) result[0];
-                    Long postCount = (Long) result[1];
+                    Long tagId = ((Number) result[0]).longValue();  // tag_id
+                    String tagName = (String) result[1];  // tag_name
+                    Long postCount = ((Number) result[2]).longValue();  // COUNT(pt.tag_id)
                     return TagInfoResponse.builder()
-                            .tagId(tag.getId())
-                            .tagName(tag.getTagName())
+                            .tagId(tagId)  // tagId 설정
+                            .tagName(tagName)  // tagName 설정
                             .postCount(postCount)
                             .build();
                 })

--- a/src/main/java/com/example/service/community/CommunityService.java
+++ b/src/main/java/com/example/service/community/CommunityService.java
@@ -8,13 +8,16 @@ import com.example.domain.service.Service;
 import com.example.dto.request.CreatePostRequest;
 import com.example.dto.request.UpdatePostRequest;
 import com.example.dto.response.MyPostResponse;
+import com.example.dto.response.TagInfoResponse;
 import com.example.exception.CustomException;
 import com.example.exception.ErrorCode;
 import com.example.repository.community.*;
 import com.example.repository.member.MemberRepository;
+import com.example.repository.plan.PlanRepository;
 import com.example.repository.service.ServiceRepository;
 import io.jsonwebtoken.Claims;
 import jakarta.servlet.http.HttpServletRequest;
+import com.example.domain.community.Tag;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.core.Authentication;
@@ -41,6 +44,8 @@ public class CommunityService {
     private final CommentRepository commentRepository;
     private final ReplyRepository replyRepository;
     private final PostLikeRepository postLikeRepository;
+    private final PlanRepository planRepository;
+
 
     // 토큰에서 사용자 ID 추출
     public String getUserIdFromToken(HttpServletRequest request) {
@@ -245,5 +250,129 @@ public class CommunityService {
         }).collect(Collectors.toList());
 
         return ApiResult.success(response);
+    }
+
+
+    /*
+    태그 기반 커뮤니티 게시글 목록 정보 조회
+    */
+//    public ApiResult<?> getPostsByTag(String tag, int limit) {
+//            PageRequest pageRequest = PageRequest.of(0, limit, Sort.by(Sort.Direction.DESC, "createdAt"));
+//
+//            List<PostsByTagInfoResponse> response = postRepository.findByTagName(tag, pageRequest)
+//                .stream()
+//                .map(this::convertToDto)
+//                .collect(Collectors.toList());
+//
+//            return ApiResult.success(response);
+//    }
+//
+////    private PostsByTagInfoResponse convertToDto(Post post) {
+//
+//        Member author = memberRepository.findById(post.getMemberId())
+//                .orElseThrow(() -> new CustomException(ErrorCode.MEMBER_NOT_FOUND));
+//
+//        List<PostTag> postTags = postTagRepository.findByPost(post);
+//        List<PostService> postServices = postServiceRepository.findByPost(post);
+//        List<Plan> plans = planRepository.findByService_Id(service.getId());
+//
+//        return PostsByTagInfoResponse.builder()
+//                .postId(post.getId())
+//                .title(post.getTitle())
+//                .content(post.getContent())
+//                .createdAt(post.getCreatedTime())
+//                //.modifiedAt(post.getModifiedAt()) modifiedAt 속성 추가시 추가 예정
+//                11.postImagePathUrls(post.getId()getPostImagePathUrls())
+//                .author(PostsByTagInfoResponse.AuthorDto.builder()
+//                        .memberId(author.getMemberId())
+//                        .username(author.getUsername())
+//                        .profileImagePathUrl(author.getProfile_path())
+//                        .build())
+//                .tags(postTags.stream()
+//                        .map(tag -> PostsByTagInfoResponse.TagsDto.builder()
+//                                .tagId(tag.getTag().getId())
+//                                .tag(tag.getTag().getTagName())
+//                                .build())
+//                        .collect(Collectors.toList()))
+//                .views(post.getViews())
+//                .services(postServices.stream()
+//                        .map(service -> PostsByTagInfoResponse.ServiceDto.builder()
+//                                .serviceId(service.getService().getId())
+//                                .planIds(planRepository.findByService_Id(service.getId()))
+//                                .name(service.getService().getName())
+//                                .url(service.getService().getUrl())
+//                                .build())
+//                        .collect(Collectors.toList()))
+//                .comments(post.getComments().stream()
+//                        .map(comment -> PostResponse.CommentDto.builder()
+//                                .comment(comment.getPostContent())
+//                                .likeCount(comment.getLikeCount())
+//                                .createdAt(comment.getCreatedTime())
+//                                .writer(PostResponse.AuthorDto.builder()
+//                                        .memberId(comment.getMember().getMemberId())
+//                                        .username(comment.getMember().getUsername())
+//                                        .profileImagePathUrl(comment.getMember().getProfileImagePathUrl())
+//                                        .build())
+//                                .replies(comment.getReplies().stream()
+//                                        .map(reply -> PostResponse.CommentDto.ReplyDto.builder()
+//                                                .reply(reply.getContent())
+//                                                .likeCount(reply.getLikeCount())
+//                                                .createdAt(reply.getCreatedTime())
+//                                                .writer(PostResponse.AuthorDto.builder()
+//                                                        .memberId(reply.getMember().getMemberId())
+//                                                        .username(reply.getMember().getUsername())
+//                                                        .profileImagePathUrl(reply.getMember().getProfileImagePathUrl())
+//                                                        .build())
+//                                                .build())
+//                                        .collect(Collectors.toList()))
+//                                .build())
+//                        .collect(Collectors.toList()))
+//                .likeCount(post.getLikeCount())
+//                .build();
+//    }
+
+
+    /*
+    추천 태그 목록 정보 조회
+    */
+    public ApiResult<?> getTop10Tags() {
+        List<Object[]> tagPostCounts = postTagRepository.findTopTagsWithPostCount();
+
+        List<TagInfoResponse> topTagsResponse = tagPostCounts.stream()
+                .limit(10)
+                .map(result -> {
+                    Tag tag = (Tag) result[0];
+                    Long postCount = (Long) result[1];
+                    return TagInfoResponse.builder()
+                            .tagId(tag.getId())
+                            .tagName(tag.getTagName())
+                            .postCount(postCount)
+                            .build();
+                })
+                .collect(Collectors.toList());
+
+        return  ApiResult.success(topTagsResponse);
+    }
+
+    /*
+    연관 검색 태그 목록 정보 조회
+    */
+
+    public ApiResult<?> getRelatedTags(String query) {
+        List<Object[]> tagPostCounts = postTagRepository.findRelatedTagsWithPostCount(query);
+
+        List<TagInfoResponse> relatedTagsResponse = tagPostCounts.stream()
+                .map(result -> {
+                    Tag tag = (Tag) result[0];
+                    Long postCount = (Long) result[1];
+                    return TagInfoResponse.builder()
+                            .tagId(tag.getId())
+                            .tagName(tag.getTagName())
+                            .postCount(postCount)
+                            .build();
+                })
+                .collect(Collectors.toList());
+
+        return  ApiResult.success(relatedTagsResponse);
     }
 }

--- a/src/main/java/com/example/service/subscribe/SubscribeService.java
+++ b/src/main/java/com/example/service/subscribe/SubscribeService.java
@@ -98,7 +98,7 @@ public class SubscribeService {
         List<TagSubInfoResponse> tagResponses = subscribedTags.stream()
                 .map(tagSub -> TagSubInfoResponse.builder()
                         .tagId(tagSub.getTag().getId())
-                        .tag(tagSub.getTag().getTagName())
+                        .tags(tagSub.getTag().getTagName())
                         .isReceiveNotification(tagSub.getSubNotify())
                         .postCount(postRepository.countPostsByTagId(tagSub.getTag().getId()))
                         .build())


### PR DESCRIPTION
## 👀 이슈

resolve #98

## 📌 개요

[추천] 태그 등록 수가 가장 높은 상위 10개의 태그 목록 정보를 조회하고자 합니다.
[연관 검색] 검색한 태그와 연관된 태그 목록 정보를 조회하고자 합니다.

## 👩‍💻 작업 사항

- 추천 태그 목록 정보 조회 
: GET /public/community/recommendation-tags

- 연관 검색 태그 목록 정보 조회 
: GET /public/community/search/related-tags?q=지구

- tag 관련 API 엔드포인트/응답 바디 수정
: tag->tags

## ✅ 참고 사항

공유할 내용 및 관련 스크린샷 등을 넣어 주세요
