### PR TITLE
[feat] 파일 업로드 기능 추가 #100

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -28,7 +28,6 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
     implementation 'org.springframework:spring-context-support'
 
-
     developmentOnly 'org.springframework.boot:spring-boot-devtools'
 
     implementation group: 'io.jsonwebtoken', name: 'jjwt-api', version: '0.11.5'

--- a/src/main/java/com/example/controller/upload/UploadController.java
+++ b/src/main/java/com/example/controller/upload/UploadController.java
@@ -1,0 +1,61 @@
+package com.example.controller.upload;
+
+import com.example.api.ApiResult;
+import com.example.service.member.MemberService;
+import com.example.service.upload.UploadService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.core.io.FileSystemResource;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.File;
+import java.util.List;
+
+@Tag(name = "사진 저장 API")
+@Slf4j
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/private/upload")
+public class UploadController {
+    private final UploadService uploadService;
+
+    private static final String UPLOAD_DIRECTORY = "buddy/"; // 상대 경로로 설정
+
+    @PostMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    @Operation(summary = "파일 업로드", description = "")
+    public ApiResult<?> uploadFile(@RequestParam("file") List<MultipartFile> files, HttpServletRequest request) {
+        return uploadService.uploadFile(files, request);
+    }
+
+    @GetMapping("/image")
+    public ResponseEntity<?> getImage(@RequestParam String path) {
+        try {
+//            String absolutePath = new File("").getAbsolutePath() + File.separator + UPLOAD_DIRECTORY + path;
+            File file = new File(path);
+
+            if (!file.exists()) {
+                return ResponseEntity.status(HttpStatus.NOT_FOUND).body("Image not found");
+            }
+
+            FileSystemResource fileSystemResource = new FileSystemResource(file);
+            HttpHeaders headers = new HttpHeaders();
+            headers.setContentType(MediaType.IMAGE_JPEG); // Adjust based on file type (JPEG, PNG, etc.)
+
+            return ResponseEntity.ok()
+                    .headers(headers)
+                    .body(fileSystemResource);
+
+        } catch (Exception e) {
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body("Error loading image");
+        }
+
+
+}}

--- a/src/main/java/com/example/repository/community/PostTagRepository.java
+++ b/src/main/java/com/example/repository/community/PostTagRepository.java
@@ -11,13 +11,13 @@ import java.util.List;
 
 public interface PostTagRepository extends JpaRepository<PostTag, Long> {
     List<PostTag> findByPost(Post post);
-//    List<Tag> findTop10ByOrderByTagCountDesc();4
+//    List<Tag> findTop10ByOrderByTagCountDesc();
 
     //태그 등록 수가 가장 높은 상위 태그 목록 조회
     @Query("SELECT pt.tag, COUNT(pt.post) FROM PostTag pt GROUP BY pt.tag ORDER BY COUNT(pt.post) DESC")
     List<Object[]> findTopTagsWithPostCount();
 
-    //특정 검색어를 포함하는 태그와 해당 태그에 대한 게시물 개수ㄴ 조회
+    //특정 검색어를 포함하는 태그와 해당 태그에 대한 게시물 개수 조회
     @Query("SELECT pt.tag, COUNT(pt.post) FROM PostTag pt WHERE pt.tag.tagName LIKE %:query% GROUP BY pt.tag ORDER BY COUNT(pt.post) DESC")
     List<Object[]> findRelatedTagsWithPostCount(@Param("query") String query);
 }

--- a/src/main/java/com/example/service/upload/UploadService.java
+++ b/src/main/java/com/example/service/upload/UploadService.java
@@ -1,0 +1,93 @@
+package com.example.service.upload;
+
+import com.example.api.ApiResult;
+import com.example.config.jwt.TokenProvider;
+import com.example.domain.member.Member;
+import com.example.exception.CustomException;
+import com.example.exception.ErrorCode;
+import com.example.repository.member.MemberRepository;
+import io.jsonwebtoken.Claims;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.Authentication;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.File;
+import java.io.IOException;
+import java.text.SimpleDateFormat;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.List;
+import java.util.UUID;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+@Slf4j
+public class UploadService {
+
+    private final MemberRepository memberRepository;
+    private final TokenProvider tokenProvider;
+
+    private static final String UPLOAD_DIRECTORY = "buddy/"; // 상대 경로로 설정
+
+    public String getUserIdFromToken(HttpServletRequest request) {
+        Authentication authentication = tokenProvider.getAuthentication(tokenProvider.resolveToken(request));
+        Claims claims = tokenProvider.getTokenClaims(tokenProvider.resolveToken(request));
+        return claims.getSubject();
+    }
+
+    public ApiResult<?> uploadFile(List<MultipartFile> files, HttpServletRequest request) {
+        String userId = getUserIdFromToken(request);
+        Member member = memberRepository.findByUserId(userId)
+                .orElseThrow(() -> new CustomException(ErrorCode.MEMBER_NOT_FOUND));
+
+        List<String> uploadedFilePaths = new ArrayList<>();
+
+        if (files == null || files.isEmpty()) {
+            return ApiResult.success(uploadedFilePaths+"ff");
+        }
+
+        // 절대 경로 생성
+        String uploadPath = request.getServletContext().getRealPath("/") + UPLOAD_DIRECTORY;
+        File uploadDir = new File(uploadPath);
+
+        // buddy 디렉토리가 없으면 생성
+        if (!uploadDir.exists()) {
+            boolean created = uploadDir.mkdirs();
+            if (!created) {
+                return ApiResult.success("Could not create upload directory.");
+            }
+        }
+
+        for (MultipartFile file : files) {
+            if (file.isEmpty()) {
+                continue;
+            }
+
+            String originalFilename = file.getOriginalFilename();
+            String fileExtension = originalFilename != null ? originalFilename.substring(originalFilename.lastIndexOf(".")) : "";
+
+            // 날짜 및 랜덤 문자열 생성
+            String dateStr = new SimpleDateFormat("yyyyMMdd").format(new Date());
+            String randomStr = UUID.randomUUID().toString().substring(0, 8);
+            String uniqueFilename = dateStr + randomStr + fileExtension;
+
+            // 절대 경로로 파일 저장
+            File destinationFile = new File(uploadPath + uniqueFilename);
+            try {
+                file.transferTo(destinationFile);
+                // 절대 경로 반환
+                uploadedFilePaths.add(destinationFile.getAbsolutePath());
+            } catch (IOException e) {
+                log.error("Failed to upload file: " + originalFilename, e);
+                return ApiResult.success("Failed to upload file: " + originalFilename);
+            }
+        }
+
+        return ApiResult.success(uploadedFilePaths);
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -11,7 +11,7 @@ spring:
   servlet:
     multipart:
       enabled: true
-      max-file-size: 5MB
+      max-file-size: 10MB
       max-request-size: 10MB
 
   datasource:


### PR DESCRIPTION
## 👀 이슈

resolve #100

## 📌 개요

사진 파일을 업로드하고자 한다.

## 👩‍💻 작업 사항

- 파일업로드
:POST, /private/upload

## ✅ 참고 사항

- 다중 업로드 가능
- 총 10MB까지 가능
- 사진 저장 확인용  API Get(/private/upload/image)
  - 사진 업로드시 반환된 경로를 해당 API에 입력하면 저장되었는지 확인할 수 있습니다.
