### PR TITLE
[feat] 태그 기반 커뮤니티 게시글 목록 정보 조회 기능 추가 #97

### DIFF
--- a/src/main/java/com/example/controller/community/CommunityController.java
+++ b/src/main/java/com/example/controller/community/CommunityController.java
@@ -18,7 +18,7 @@ import java.util.List;
 @Slf4j
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/private/community")
+@RequestMapping
 public class CommunityController {
 
     private final CommunityService communityService;
@@ -47,11 +47,11 @@ public class CommunityController {
         return communityService.getMyCommunityPosts(request);
     }
 
-//    @Operation(summary = "태그 기반 커뮤니티 게시글 목록 정보 조회", description = "")
-//    @GetMapping("/public/community/posts")
-//    public ApiResult<?> getPostsByTag(@RequestParam String tag, @RequestParam int limit) {
-//        return communityService.getPostsByTag(tag, limit);
-//    }
+    @Operation(summary = "태그 기반 커뮤니티 게시글 목록 정보 조회", description = "")
+    @GetMapping("/public/community/posts")
+    public ApiResult<?> getPostsByTag(@RequestParam String tag, @RequestParam int limit) {
+        return communityService.getPostsByTag(tag, limit);
+    }
 
     @Operation(summary = "추천 태그 목록 정보 조회", description = "태그 등록 수가 가장 높은 상위 10개의 태그 목록 정보를 조회한다.")
     @GetMapping("/public/community/recommendation-tags")

--- a/src/main/java/com/example/dto/response/PostsByTagInfoResponse.java
+++ b/src/main/java/com/example/dto/response/PostsByTagInfoResponse.java
@@ -1,5 +1,6 @@
 package com.example.dto.response;
 
+import com.example.domain.community.Photo;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.Setter;
@@ -14,15 +15,23 @@ public class PostsByTagInfoResponse {
     private Long postId;
     private String title;
     private String content;
-    private LocalDateTime createdAt;
-//    private LocalDateTime modifiedAt;
-    private List<String> postImagePathUrls;
+    private String createdAt;
+//    private String modifiedAt;
+    private List<PhotoDto> postImagePathUrls;
     private AuthorDto author;
     private List<TagsDto> tags;
     private int views;
     private List<ServiceDto> services;
     private List<CommentDto> comments;
     private int likeCount;
+
+
+    @Getter
+    @Setter
+    @Builder
+    public static class PhotoDto {
+        private String photoPath;
+    }
 
     @Getter
     @Setter
@@ -57,7 +66,7 @@ public class PostsByTagInfoResponse {
     public static class CommentDto {
         private String comment;
         private int likeCount;
-        private LocalDateTime createdAt;
+        private String createdAt;
         private AuthorDto writer;
         private List<ReplyDto> replies;
 
@@ -67,7 +76,7 @@ public class PostsByTagInfoResponse {
         public static class ReplyDto {
             private String reply;
             private int likeCount;
-            private LocalDateTime createdAt;
+            private String createdAt;
             private AuthorDto writer;
         }
     }

--- a/src/main/java/com/example/repository/community/CommentRepository.java
+++ b/src/main/java/com/example/repository/community/CommentRepository.java
@@ -1,8 +1,13 @@
 package com.example.repository.community;
 
 import com.example.domain.community.Comment;
+import com.example.domain.community.Post;
 import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
 
 public interface CommentRepository extends JpaRepository<Comment, Long> {
     int countByPostId(Long postId);
+
+    List<Comment> findByPost(Post post);
 }

--- a/src/main/java/com/example/repository/community/PostRepository.java
+++ b/src/main/java/com/example/repository/community/PostRepository.java
@@ -3,10 +3,11 @@ package com.example.repository.community;
 import com.example.domain.community.Post;
 import com.example.domain.member.Member;
 import io.lettuce.core.dynamic.annotation.Param;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 
-import java.awt.print.Pageable;
 import java.util.List;
 
 public interface PostRepository extends JpaRepository<Post, Long> {
@@ -14,8 +15,6 @@ public interface PostRepository extends JpaRepository<Post, Long> {
 
     @Query("SELECT COUNT(p) FROM PostTag p WHERE p.tag.id = :tagId")
     Long countPostsByTagId(@Param("tagId") Long tagId);
-
-//    @Query("SELECT p FROM Post p JOIN p.tags t WHERE t.tagName = :tag ORDER BY p.createdAt DESC")
-//    List<Post> findByTagName(@Param("tag") String tag, Pageable pageable);
-
+    @Query("SELECT p FROM Post p JOIN p.postTags pt JOIN pt.tag t WHERE t.tagName = :tag ORDER BY p.createdTime DESC")
+    Page<Post> findByTagName(@Param("tag") String tag, Pageable pageable);
 }

--- a/src/main/java/com/example/repository/community/PostTagRepository.java
+++ b/src/main/java/com/example/repository/community/PostTagRepository.java
@@ -7,11 +7,12 @@ import io.lettuce.core.dynamic.annotation.Param;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 
+import java.awt.print.Pageable;
 import java.util.List;
 
 public interface PostTagRepository extends JpaRepository<PostTag, Long> {
     List<PostTag> findByPost(Post post);
-//    List<Tag> findTop10ByOrderByTagCountDesc();
+
 
     //태그 등록 수가 가장 높은 상위 태그 목록 조회
     @Query("SELECT pt.tag, COUNT(pt.post) FROM PostTag pt GROUP BY pt.tag ORDER BY COUNT(pt.post) DESC")

--- a/src/main/java/com/example/repository/community/ReplyRepository.java
+++ b/src/main/java/com/example/repository/community/ReplyRepository.java
@@ -4,7 +4,10 @@ import com.example.domain.community.Reply;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
+
 @Repository
 public interface ReplyRepository extends JpaRepository<Reply, Long> {
     int countByCommentPostId(Long postId);
+    List<Reply> findByCommentId(Long commentId);
 }

--- a/src/main/java/com/example/service/community/CommunityService.java
+++ b/src/main/java/com/example/service/community/CommunityService.java
@@ -4,10 +4,12 @@ import com.example.api.ApiResult;
 import com.example.config.jwt.TokenProvider;
 import com.example.domain.community.*;
 import com.example.domain.member.Member;
+import com.example.domain.plan.Plan;
 import com.example.domain.service.Service;
 import com.example.dto.request.CreatePostRequest;
 import com.example.dto.request.UpdatePostRequest;
 import com.example.dto.response.MyPostResponse;
+import com.example.dto.response.PostsByTagInfoResponse;
 import com.example.dto.response.TagInfoResponse;
 import com.example.exception.CustomException;
 import com.example.exception.ErrorCode;
@@ -20,10 +22,15 @@ import jakarta.servlet.http.HttpServletRequest;
 import com.example.domain.community.Tag;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
 import org.springframework.security.core.Authentication;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.awt.print.Pageable;
 import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -253,80 +260,93 @@ public class CommunityService {
     /*
     태그 기반 커뮤니티 게시글 목록 정보 조회
     */
-//    public ApiResult<?> getPostsByTag(String tag, int limit) {
-//            PageRequest pageRequest = PageRequest.of(0, limit, Sort.by(Sort.Direction.DESC, "createdAt"));
-//
-//            List<PostsByTagInfoResponse> response = postRepository.findByTagName(tag, pageRequest)
-//                .stream()
-//                .map(this::convertToDto)
-//                .collect(Collectors.toList());
-//
-//            return ApiResult.success(response);
-//    }
-//
-////    private PostsByTagInfoResponse convertToDto(Post post) {
-//
-//        Member author = memberRepository.findById(post.getMemberId())
-//                .orElseThrow(() -> new CustomException(ErrorCode.MEMBER_NOT_FOUND));
-//
-//        List<PostTag> postTags = postTagRepository.findByPost(post);
-//        List<PostService> postServices = postServiceRepository.findByPost(post);
-//        List<Plan> plans = planRepository.findByService_Id(service.getId());
-//
-//        return PostsByTagInfoResponse.builder()
-//                .postId(post.getId())
-//                .title(post.getTitle())
-//                .content(post.getContent())
-//                .createdAt(post.getCreatedTime())
-//                //.modifiedAt(post.getModifiedAt()) modifiedAt 속성 추가시 추가 예정
-//                11.postImagePathUrls(post.getId()getPostImagePathUrls())
-//                .author(PostsByTagInfoResponse.AuthorDto.builder()
-//                        .memberId(author.getMemberId())
-//                        .username(author.getUsername())
-//                        .profileImagePathUrl(author.getProfile_path())
-//                        .build())
-//                .tags(postTags.stream()
-//                        .map(tag -> PostsByTagInfoResponse.TagsDto.builder()
-//                                .tagId(tag.getTag().getId())
-//                                .tag(tag.getTag().getTagName())
-//                                .build())
-//                        .collect(Collectors.toList()))
-//                .views(post.getViews())
-//                .services(postServices.stream()
-//                        .map(service -> PostsByTagInfoResponse.ServiceDto.builder()
-//                                .serviceId(service.getService().getId())
-//                                .planIds(planRepository.findByService_Id(service.getId()))
-//                                .name(service.getService().getName())
-//                                .url(service.getService().getUrl())
-//                                .build())
-//                        .collect(Collectors.toList()))
-//                .comments(post.getComments().stream()
-//                        .map(comment -> PostResponse.CommentDto.builder()
-//                                .comment(comment.getPostContent())
-//                                .likeCount(comment.getLikeCount())
-//                                .createdAt(comment.getCreatedTime())
-//                                .writer(PostResponse.AuthorDto.builder()
-//                                        .memberId(comment.getMember().getMemberId())
-//                                        .username(comment.getMember().getUsername())
-//                                        .profileImagePathUrl(comment.getMember().getProfileImagePathUrl())
-//                                        .build())
-//                                .replies(comment.getReplies().stream()
-//                                        .map(reply -> PostResponse.CommentDto.ReplyDto.builder()
-//                                                .reply(reply.getContent())
-//                                                .likeCount(reply.getLikeCount())
-//                                                .createdAt(reply.getCreatedTime())
-//                                                .writer(PostResponse.AuthorDto.builder()
-//                                                        .memberId(reply.getMember().getMemberId())
-//                                                        .username(reply.getMember().getUsername())
-//                                                        .profileImagePathUrl(reply.getMember().getProfileImagePathUrl())
-//                                                        .build())
-//                                                .build())
-//                                        .collect(Collectors.toList()))
-//                                .build())
-//                        .collect(Collectors.toList()))
-//                .likeCount(post.getLikeCount())
-//                .build();
-//    }
+    public ApiResult<?> getPostsByTag(String tagName, int limit) {
+
+        PageRequest pageRequest = PageRequest.of(0, limit, Sort.by(Sort.Direction.DESC, "createdTime"));
+        Page<Post> postPage = postRepository.findByTagName(tagName, pageRequest);
+
+        List<PostsByTagInfoResponse> response = postPage.stream()
+                .map(this::convertToDto)
+                .collect(Collectors.toList());
+
+            return ApiResult.success(response);
+    }
+
+    private PostsByTagInfoResponse convertToDto(Post post) {
+        List<PostTag> postTags = postTagRepository.findByPost(post);
+        List<Photo> photos = photoRepository.findByPost(post);
+        List<PostService> postServices = postServiceRepository.findByPost(post);
+        List<Comment> comments = commentRepository.findByPost(post);
+        List<PostsByTagInfoResponse.CommentDto> commentDtos = comments.stream()
+                .map(comment -> {
+                            // 리플라이 조회
+                            List<Reply> replies = replyRepository.findByCommentId(comment.getId());
+
+                            List<PostsByTagInfoResponse.CommentDto.ReplyDto> replyDtos = replies.stream()
+                                    .map(reply -> PostsByTagInfoResponse.CommentDto.ReplyDto.builder()
+                                            .reply(reply.getContent())
+//                                            .likeCount(reply.getLikeCount())
+                                            .createdAt(reply.getCreatedTime().format(DateTimeFormatter.ISO_DATE_TIME))
+                                            .writer(PostsByTagInfoResponse.AuthorDto.builder()
+                                                    .memberId(reply.getMember().getMemberId())
+                                                    .username(reply.getMember().getUsername())
+                                                    .profileImagePathUrl(reply.getMember().getProfile_path())
+                                                    .build())
+                                            .build())
+                                    .collect(Collectors.toList());
+
+                    return PostsByTagInfoResponse.CommentDto.builder()
+                            .comment(comment.getPostContent())
+//                            .likeCount(comment.getLikeCount())
+                            .createdAt(comment.getCreatedTime().format(DateTimeFormatter.ISO_DATE_TIME))
+                            .writer(PostsByTagInfoResponse.AuthorDto.builder()
+                                    .memberId(comment.getMember().getMemberId())
+                                    .username(comment.getMember().getUsername())
+                                    .profileImagePathUrl(comment.getMember().getProfile_path())
+                                    .build())
+                            .replies(replyDtos)
+                            .build();
+                })
+
+                .collect(Collectors.toList());
+
+        return PostsByTagInfoResponse.builder()
+                .postId(post.getId())
+                .title(post.getTitle())
+                .content(post.getContent())
+                .createdAt(post.getCreatedTime().format(DateTimeFormatter.ISO_DATE_TIME))
+                //.modifiedAt(post.getModifiedAt()) modifiedAt 속성 추가시 추가 예정
+                .postImagePathUrls(photos.stream()
+                        .map(photo -> PostsByTagInfoResponse.PhotoDto.builder()
+                                .photoPath(photo.getPhotoPath())
+                                .build())
+                        .collect(Collectors.toList()))
+                .author(PostsByTagInfoResponse.AuthorDto.builder()
+                        .memberId(post.getMember().getMemberId())
+                        .username(post.getMember().getUsername())
+                        .profileImagePathUrl(post.getMember().getProfile_path())
+                        .build())
+                .tags(postTags.stream()
+                        .map(tag -> PostsByTagInfoResponse.TagsDto.builder()
+                                .tagId(tag.getTag().getId())
+                                .tag(tag.getTag().getTagName())
+                                .build())
+                        .collect(Collectors.toList()))
+                .views(post.getViews())
+                .services(postServices.stream()
+                        .map(postService -> PostsByTagInfoResponse.ServiceDto.builder()
+                                .serviceId(postService.getService().getId())
+                                .planIds(planRepository.findByService_Id(postService.getService().getId()).stream()
+                                    .map(Plan::getId)
+                                    .collect(Collectors.toList()))
+                                .name(postService.getService().getServiceName())
+                                .url(postService.getService().getUrl())
+                                .build())
+                        .collect(Collectors.toList()))
+                .comments(commentDtos)
+                .likeCount(postLikeRepository.countByPostId(post.getId()))
+                .build();
+    }
 
 
     /*


### PR DESCRIPTION
## 👀 이슈

resolve #97

## 📌 개요

태그명(tag)과 조회될 게시글의 최댓값(limit)을 Query String으로 전달하여 게시글 목록 정보를 조회한다.

## 👩‍💻 작업 사항

- 태그 기반 커뮤니티 게시글 목록 정보 조회
: GET /public/community/posts?tag=애니메이션&limit=5)

## ✅ 참고 사항

추후 추가 필요한 항목
- 수정시간(modifyAt)
- 댓글 및 답글 좋아요 (comment/replyLikeCount) 
