### PR TITLE
[feat] 커뮤니티 게시글 정보 조회 API 추가 #104

### DIFF
--- a/src/main/java/com/example/controller/community/CommunityController.java
+++ b/src/main/java/com/example/controller/community/CommunityController.java
@@ -65,5 +65,9 @@ public class CommunityController {
         return communityService.getRelatedTags(query);
     }
 
-
+    @Operation(summary = "커뮤니티 게시글 정보 조회", description = "")
+    @GetMapping("/public/community/posts/{postId}")
+    public ApiResult<?> getPostById(@PathVariable Long postId) {
+        return communityService.getPostById(postId);
+    }
 }

--- a/src/main/java/com/example/dto/response/CommunityPostResponse.java
+++ b/src/main/java/com/example/dto/response/CommunityPostResponse.java
@@ -1,0 +1,73 @@
+package com.example.dto.response;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.util.List;
+
+@Getter
+@Setter
+@Builder
+public class CommunityPostResponse {
+    private Long postId;
+    private String title;
+    private String content;
+    private String createdAt;
+    private String modifiedAt;
+    private List<String> postImagePathUrls;
+    private AuthorDto author;
+    private List<TagDto> tags;
+    private int views;
+    private List<ServiceDto> services;
+    private List<CommentDto> comments;
+    private int likeCount;
+
+    @Getter
+    @Setter
+    @Builder
+    public static class AuthorDto {
+        private Long memberId;
+        private String username;
+        private String profileImagePathUrl;
+    }
+
+    @Getter
+    @Setter
+    @Builder
+    public static class TagDto {
+        private Long tagId;
+        private String tag;
+    }
+
+    @Getter
+    @Setter
+    @Builder
+    public static class ServiceDto {
+        private Long serviceId;
+        private List<Long> planIds;
+        private String name;
+        private String url;
+    }
+
+    @Getter
+    @Setter
+    @Builder
+    public static class CommentDto {
+        private String comment;
+        private int likeCount;
+        private String createdAt;
+        private AuthorDto writer;
+        private List<ReplyDto> replies;
+
+        @Getter
+        @Setter
+        @Builder
+        public static class ReplyDto {
+            private String reply;
+            private int likeCount;
+            private String createdAt;
+            private AuthorDto writer;
+        }
+    }
+}


### PR DESCRIPTION
## 👀 이슈

resolve #104

## 📌 개요

커뮤니티 게시글에 대한 정보를 조회할 수 있는 API를 구현했습니다. 

## 👩‍💻 작업 사항

- 커뮤니티 게시글 조회 API 구현: GET /public/community/posts/{postId}
- DTO 추가: CommunityPostResponse 클래스 추가 
- 컨트롤러 및 서비스 구현: CommunityController 및 CommunityService에 API 로직 추가

## ✅ 참고 사항

공유할 내용 및 관련 스크린샷 등을 넣어 주세요
