### PR TITLE
[feat] 최신 커뮤니티 게시글 목록 조회 API 추가 #106

### DIFF
--- a/src/main/java/com/example/controller/community/CommunityController.java
+++ b/src/main/java/com/example/controller/community/CommunityController.java
@@ -3,6 +3,7 @@ package com.example.controller.community;
 import com.example.api.ApiResult;
 import com.example.dto.request.CreatePostRequest;
 import com.example.dto.request.UpdatePostRequest;
+import com.example.dto.response.CommunityPostResponse;
 import com.example.dto.response.MyPostResponse;
 import com.example.service.community.CommunityService;
 import io.swagger.v3.oas.annotations.Operation;
@@ -69,5 +70,11 @@ public class CommunityController {
     @GetMapping("/public/community/posts/{postId}")
     public ApiResult<?> getPostById(@PathVariable Long postId) {
         return communityService.getPostById(postId);
+    }
+
+    @Operation(summary = "커뮤니티 최신 게시글 목록 정보 조회", description = "")
+    @GetMapping("/public/community/posts/latest")
+    public ApiResult<List<CommunityPostResponse>> getLatestPosts(@RequestParam int limit) {
+        return communityService.getLatestPosts(limit);
     }
 }

--- a/src/main/java/com/example/dto/response/CommunityPostResponse.java
+++ b/src/main/java/com/example/dto/response/CommunityPostResponse.java
@@ -22,6 +22,7 @@ public class CommunityPostResponse {
     private List<ServiceDto> services;
     private List<CommentDto> comments;
     private int likeCount;
+    private int commentCount;
 
     @Getter
     @Setter


### PR DESCRIPTION
## 👀 이슈

resolve #106

## 📌 개요

최신 커뮤니티 게시글 목록을 조회할 수 있는 API를 추가하였습니다.

## 👩‍💻 작업 사항

- 최신 커뮤니티 게시글 목록 조회 API 구현: GET /public/community/posts/latest?limit={limit}
- 컨트롤러 및 서비스 구현: CommunityController와 CommunityService에 최신 게시글 조회 로직 추가

## ✅ 참고 사항

기존에 /public/community/posts 경로가 태그 기반 게시글 조회 API와 중복될 수 있어, 최신 게시글 조회를 위한 경로를 /public/community/posts/latest로 변경하였습니다.