### PR TITLE
[feat] 댓글 좋아요/취소 API 추가 #109

### DIFF
--- a/src/main/java/com/example/controller/community/CommentController.java
+++ b/src/main/java/com/example/controller/community/CommentController.java
@@ -36,4 +36,16 @@ public class CommentController {
     public ApiResult<?> updateComment(@PathVariable Long commentId, @RequestBody CommentRequest commentRequest) {
         return commentService.updateComment(commentId, commentRequest.getContent());
     }
+
+    @Operation(summary = "댓글 좋아요 누르기", description = "")
+    @PostMapping("/comments/{commentId}/like")
+    public ApiResult<String> likeComment(@PathVariable Long commentId, HttpServletRequest request) {
+        return commentService.likeComment(request, commentId);
+    }
+
+    @Operation(summary = "댓글 좋아요 취소하기", description = "")
+    @DeleteMapping("/comments/{commentId}/like")
+    public ApiResult<String> unlikeComment(@PathVariable Long commentId, HttpServletRequest request) {
+        return commentService.unlikeComment(request, commentId);
+    }
 }

--- a/src/main/java/com/example/domain/community/CommentLike.java
+++ b/src/main/java/com/example/domain/community/CommentLike.java
@@ -1,0 +1,33 @@
+package com.example.domain.community;
+
+import com.example.domain.member.Member;
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Entity
+@NoArgsConstructor
+public class CommentLike {
+
+    @EmbeddedId
+    private CommentLikeId id;
+
+    @ManyToOne
+    @MapsId("memberId")
+    @JoinColumn(name = "member_id")
+    private Member member;
+
+    @ManyToOne
+    @MapsId("commentId")
+    @JoinColumn(name = "comment_id")
+    private Comment comment;
+
+    public CommentLike(Member member, Comment comment) {
+        this.id = new CommentLikeId(member.getMemberId(), comment.getId());
+        this.member = member;
+        this.comment = comment;
+    }
+}

--- a/src/main/java/com/example/domain/community/CommentLikeId.java
+++ b/src/main/java/com/example/domain/community/CommentLikeId.java
@@ -1,0 +1,18 @@
+package com.example.domain.community;
+
+import jakarta.persistence.Embeddable;
+import lombok.AllArgsConstructor;
+import lombok.EqualsAndHashCode;
+import lombok.NoArgsConstructor;
+
+import java.io.Serializable;
+
+@Embeddable
+@EqualsAndHashCode
+@NoArgsConstructor
+@AllArgsConstructor
+public class CommentLikeId implements Serializable {
+
+    private Long memberId;
+    private Long commentId;
+}

--- a/src/main/java/com/example/exception/ErrorCode.java
+++ b/src/main/java/com/example/exception/ErrorCode.java
@@ -17,6 +17,8 @@ public enum ErrorCode {
     INVALID_SERVICE_ID(HttpStatus.BAD_REQUEST, "존재하지 않는 서비스입니다."),
     LEADER_CANNOT_LEAVE_PARTY(HttpStatus.BAD_REQUEST, "파티장은 파티를 탈퇴할 수 없습니다."),
     NOT_LIKED_YET(HttpStatus.BAD_REQUEST, "아직 좋아요를 누르지 않은 게시글입니다."),
+    COMMENT_NOT_LIKED_YET(HttpStatus.BAD_REQUEST, "아직 좋아요를 누르지 않은 댓글입니다."),
+
 
 
     // 401 UNAUTHORIZED
@@ -49,6 +51,7 @@ public enum ErrorCode {
     ALREADY_ON_NOTIFY(HttpStatus.CONFLICT, "이미 해당 태그에 대한 신규 게시글 알림이 켜져있습니다."),
     ALREADY_OFF_NOTIFY(HttpStatus.CONFLICT, "이미 해당 태그에 대한 신규 게시글 알림이 꺼져있습니다."),
     ALREADY_LIKED(HttpStatus.CONFLICT, "이미 좋아요를 누른 게시글입니다."),
+    ALREADY_COMMENT_LIKED(HttpStatus.CONFLICT, "이미 좋아요를 누른 댓글입니다."),
     ALREADY_PAYMENT_KEY(HttpStatus.CONFLICT, "이미 존재하는 결제 키입니다.");
 
     private final HttpStatus httpStatus;

--- a/src/main/java/com/example/repository/community/CommentLikeRepository.java
+++ b/src/main/java/com/example/repository/community/CommentLikeRepository.java
@@ -1,0 +1,8 @@
+package com.example.repository.community;
+
+import com.example.domain.community.CommentLike;
+import com.example.domain.community.CommentLikeId;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CommentLikeRepository extends JpaRepository<CommentLike, CommentLikeId> {
+}


### PR DESCRIPTION
## 👀 이슈

resolve #109 

## 📌 개요

댓글에 좋아요 및 좋아요 취소 기능을 추가했습니다.

## 👩‍💻 작업 사항

- 댓글 좋아요 기능 추가: POST, /private/posts/comments/{commentId}/like API를 통해 사용자가 댓글에 좋아요를 누를 수 있도록 구현.
- 댓글 좋아요 취소 기능 추가: DELETE, /private/posts/comments/{commentId}/like API를 통해 사용자가 댓글에 이미 누른 좋아요를 취소할 수 있도록 구현.

## ✅ 참고 사항

없습니다.
