### PR TITLE
[feat] 답글 좋아요/취소 API 추가 #109-111

### DIFF
--- a/src/main/java/com/example/controller/community/ReplyController.java
+++ b/src/main/java/com/example/controller/community/ReplyController.java
@@ -36,4 +36,16 @@ public class ReplyController {
     public ApiResult<?> updateReply(@PathVariable Long replyId, @RequestBody CommentRequest commentRequest) {
         return replyService.updateReply(replyId, commentRequest.getContent());
     }
+
+    @Operation(summary = "답글 좋아요 누르기", description = "")
+    @PostMapping("/replies/{replyId}/like")
+    public ApiResult<String> likeReply(@PathVariable Long replyId, HttpServletRequest request) {
+        return replyService.likeReply(request, replyId);
+    }
+
+    @Operation(summary = "답글 좋아요 취소하기", description = "")
+    @DeleteMapping("/replies/{replyId}/like")
+    public ApiResult<String> unlikeReply(@PathVariable Long replyId, HttpServletRequest request) {
+        return replyService.unlikeReply(request, replyId);
+    }
 }

--- a/src/main/java/com/example/domain/community/ReplyLike.java
+++ b/src/main/java/com/example/domain/community/ReplyLike.java
@@ -1,0 +1,33 @@
+package com.example.domain.community;
+
+import com.example.domain.member.Member;
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Entity
+@NoArgsConstructor
+public class ReplyLike {
+
+    @EmbeddedId
+    private ReplyLikeId id;
+
+    @ManyToOne
+    @MapsId("memberId")
+    @JoinColumn(name = "member_id")
+    private Member member;
+
+    @ManyToOne
+    @MapsId("replyId")
+    @JoinColumn(name = "reply_id")
+    private Reply reply;
+
+    public ReplyLike(Member member, Reply reply) {
+        this.id = new ReplyLikeId(member.getMemberId(), reply.getId());
+        this.member = member;
+        this.reply = reply;
+    }
+}

--- a/src/main/java/com/example/domain/community/ReplyLikeId.java
+++ b/src/main/java/com/example/domain/community/ReplyLikeId.java
@@ -1,0 +1,18 @@
+package com.example.domain.community;
+
+import jakarta.persistence.Embeddable;
+import lombok.AllArgsConstructor;
+import lombok.EqualsAndHashCode;
+import lombok.NoArgsConstructor;
+
+import java.io.Serializable;
+
+@Embeddable
+@EqualsAndHashCode
+@NoArgsConstructor
+@AllArgsConstructor
+public class ReplyLikeId implements Serializable {
+
+    private Long memberId;
+    private Long replyId;
+}

--- a/src/main/java/com/example/exception/ErrorCode.java
+++ b/src/main/java/com/example/exception/ErrorCode.java
@@ -18,7 +18,7 @@ public enum ErrorCode {
     LEADER_CANNOT_LEAVE_PARTY(HttpStatus.BAD_REQUEST, "파티장은 파티를 탈퇴할 수 없습니다."),
     NOT_LIKED_YET(HttpStatus.BAD_REQUEST, "아직 좋아요를 누르지 않은 게시글입니다."),
     COMMENT_NOT_LIKED_YET(HttpStatus.BAD_REQUEST, "아직 좋아요를 누르지 않은 댓글입니다."),
-
+    REPLY_NOT_LIKED_YET(HttpStatus.BAD_REQUEST, "아직 좋아요를 누르지 않은 답글입니다."),
 
 
     // 401 UNAUTHORIZED
@@ -52,6 +52,7 @@ public enum ErrorCode {
     ALREADY_OFF_NOTIFY(HttpStatus.CONFLICT, "이미 해당 태그에 대한 신규 게시글 알림이 꺼져있습니다."),
     ALREADY_LIKED(HttpStatus.CONFLICT, "이미 좋아요를 누른 게시글입니다."),
     ALREADY_COMMENT_LIKED(HttpStatus.CONFLICT, "이미 좋아요를 누른 댓글입니다."),
+    ALREADY_REPLY_LIKED(HttpStatus.CONFLICT, "이미 좋아요를 누른 답글입니다."),
     ALREADY_PAYMENT_KEY(HttpStatus.CONFLICT, "이미 존재하는 결제 키입니다.");
 
     private final HttpStatus httpStatus;

--- a/src/main/java/com/example/repository/community/ReplyLikeRepository.java
+++ b/src/main/java/com/example/repository/community/ReplyLikeRepository.java
@@ -1,0 +1,8 @@
+package com.example.repository.community;
+
+import com.example.domain.community.ReplyLike;
+import com.example.domain.community.ReplyLikeId;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ReplyLikeRepository extends JpaRepository<ReplyLike, ReplyLikeId> {
+}


### PR DESCRIPTION
## 👀 이슈

resolve #111

## 📌 개요

답글에 좋아요 및 좋아요 취소 기능을 추가하였습니다. 

## 👩‍💻 작업 사항

- 답글 좋아요 API 추가: POST,  /private/comments/replies/{replyId}/like 경로를 통해 특정 답글에 좋아요를 누를 수 있도록 구현하였습니다.
- 답글 좋아요 취소 API 추가: DELETE, /private/comments/replies/{replyId}/like 경로를 통해 특정 답글에 대한 좋아요를 취소할 수 있도록 구현하였습니다.

## ✅ 참고 사항

없습니다.
