### PR TITLE
[fix] 기존 {post_like} 테이블명의 복수형으로 수정 및 {좋아요 취소하기} API 관련 400 에러 반환 코드의 404 에러가 반환되도록 수정 #114

### DIFF
--- a/src/main/java/com/example/controller/community/PostLikeController.java
+++ b/src/main/java/com/example/controller/community/PostLikeController.java
@@ -7,7 +7,6 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 @Tag(name = "게시글 좋아요 API")

--- a/src/main/java/com/example/domain/community/ReplyLike.java
+++ b/src/main/java/com/example/domain/community/ReplyLike.java
@@ -6,6 +6,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 
+@Table(name = "reply_likes")
 @Getter
 @Setter
 @Entity

--- a/src/main/java/com/example/exception/ErrorCode.java
+++ b/src/main/java/com/example/exception/ErrorCode.java
@@ -16,10 +16,7 @@ public enum ErrorCode {
     PARTY_ALREADY_STARTED(HttpStatus.BAD_REQUEST, "시작된 파티의 모집 인원은 변경할 수 없습니다."),
     INVALID_SERVICE_ID(HttpStatus.BAD_REQUEST, "존재하지 않는 서비스입니다."),
     LEADER_CANNOT_LEAVE_PARTY(HttpStatus.BAD_REQUEST, "파티장은 파티를 탈퇴할 수 없습니다."),
-    NOT_LIKED_YET(HttpStatus.BAD_REQUEST, "아직 좋아요를 누르지 않은 게시글입니다."),
-    COMMENT_NOT_LIKED_YET(HttpStatus.BAD_REQUEST, "아직 좋아요를 누르지 않은 댓글입니다."),
-    REPLY_NOT_LIKED_YET(HttpStatus.BAD_REQUEST, "아직 좋아요를 누르지 않은 답글입니다."),
-  
+    
     // 401 UNAUTHORIZED
     UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "인증 정보가 없습니다. 다시 로그인 하세요"),
 

--- a/src/main/java/com/example/service/community/PostLikeService.java
+++ b/src/main/java/com/example/service/community/PostLikeService.java
@@ -63,7 +63,7 @@ public class PostLikeService {
 
         PostLikeId postLikeId = new PostLikeId(member.getMemberId(), postId);
         if (!postLikeRepository.existsById(postLikeId)) {
-            throw new CustomException(ErrorCode.NOT_LIKED_YET);
+            throw new CustomException(ErrorCode.POST_NOT_FOUND);
         }
 
         postLikeRepository.deleteById(postLikeId);

--- a/src/main/java/com/example/service/community/ReplyService.java
+++ b/src/main/java/com/example/service/community/ReplyService.java
@@ -109,7 +109,7 @@ public class ReplyService {
 
         ReplyLikeId replyLikeId = new ReplyLikeId(member.getMemberId(), replyId);
         if (!replyLikeRepository.existsById(replyLikeId)) {
-            throw new CustomException(ErrorCode.REPLY_NOT_LIKED_YET);
+            throw new CustomException(ErrorCode.REPLY_NOT_FOUND);
         }
 
         replyLikeRepository.deleteById(replyLikeId);


### PR DESCRIPTION
## 👀 이슈

resolve #114 

## 📌 개요

#111 작업을 통해 추가되었던 `답글 좋아요 취소하기` API에서 DB에 존재하지 않는
데이터에 대하여 요청을 시도할 경우 400 에러가 발생하였는데, 이를 404 에러로
반환되도록 관련 코드를 수정하고자 하였습니다. 추가적으로, `게시글 좋아요 취소하기` API의
경우도 위와 같은 맥락에서 관련 코드를 수정하였습니다.

## 👩‍💻 작업 사항

- 기존 `post_like` 테이블명을 복수 명사로 변경(`post_likes`)
- `게시글 좋아요 취소하기` API의 400 에러를 404 에러로 반환되도록 수정
- `답글 좋아요 취소하기` API의 400 에러를 404 에러로 반환되도록 수정

## ✅ 참고 사항

없습니다