### PR TITLE
[feat] 게시글 검색 정보 조회 / 태그 관련 통합 검색 정보 조회기능 추가 #113-108

### DIFF
--- a/src/main/java/com/example/controller/community/CommunityController.java
+++ b/src/main/java/com/example/controller/community/CommunityController.java
@@ -5,6 +5,7 @@ import com.example.dto.request.CreatePostRequest;
 import com.example.dto.request.UpdatePostRequest;
 import com.example.dto.response.CommunityPostResponse;
 import com.example.dto.response.MyPostResponse;
+import com.example.dto.response.PostsByTagInfoResponse;
 import com.example.service.community.CommunityService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -42,18 +43,6 @@ public class CommunityController {
         return communityService.deletePost(postId, request);
     }
 
-    @Operation(summary = "내가 쓴 커뮤니티 게시글 목록 조회", description = "")
-    @GetMapping("/private/community/posts/my")
-    public ApiResult<List<MyPostResponse>> getMyCommunityPosts(HttpServletRequest request) {
-        return communityService.getMyCommunityPosts(request);
-    }
-
-    @Operation(summary = "태그 기반 커뮤니티 게시글 목록 정보 조회", description = "")
-    @GetMapping("/public/community/posts")
-    public ApiResult<?> getPostsByTag(@RequestParam String tag, @RequestParam int limit) {
-        return communityService.getPostsByTag(tag, limit);
-    }
-
     @Operation(summary = "추천 태그 목록 정보 조회", description = "태그 등록 수가 가장 높은 상위 10개의 태그 목록 정보를 조회한다.")
     @GetMapping("/public/community/recommendation-tags")
     public ApiResult<?> getTop10Tags() {
@@ -61,9 +50,21 @@ public class CommunityController {
     }
 
     @Operation(summary = "연관 검색 태그 목록 정보 조회", description = "특정 검색어를 포함하는 태그 목록 정보를 조회한다.")
-    @GetMapping("/public/community/search")
+    @GetMapping("/public/community/search/related-tags")
     public ApiResult<?> getRelatedTags(@RequestParam String query) {
         return communityService.getRelatedTags(query);
+    }
+
+    @Operation(summary = "내가 쓴 커뮤니티 게시글 목록 정보 조회", description = "")
+    @GetMapping("/private/community/posts/my")
+    public ApiResult<List<PostsByTagInfoResponse>> getMyCommunityPosts(HttpServletRequest request) {
+        return communityService.getMyCommunityPosts(request);
+    }
+
+    @Operation(summary = "태그 기반 커뮤니티 게시글 목록 정보 조회", description = "")
+    @GetMapping("/public/community/posts")
+    public ApiResult<?> getPostsByTag(@RequestParam String tag, @RequestParam int limit) {
+        return communityService.getPostsByTag(tag, limit);
     }
 
     @Operation(summary = "커뮤니티 게시글 정보 조회", description = "")
@@ -74,7 +75,19 @@ public class CommunityController {
 
     @Operation(summary = "커뮤니티 최신 게시글 목록 정보 조회", description = "")
     @GetMapping("/public/community/posts/latest")
-    public ApiResult<List<CommunityPostResponse>> getLatestPosts(@RequestParam int limit) {
+    public ApiResult<List<PostsByTagInfoResponse>> getLatestPosts(@RequestParam int limit) {
         return communityService.getLatestPosts(limit);
+    }
+
+    @Operation(summary = "게시글 검색 정보 조회", description = "")
+    @GetMapping("/public/community/search/posts")
+    public ApiResult<?> searchQuery(@RequestParam String q, @RequestParam int limit) {
+        return communityService.searchQuery(q,limit);
+    }
+
+    @Operation(summary = "태그 관련 통합 검색 정보 조회", description = "")
+    @GetMapping("/public/community/search/tags")
+    public ApiResult<?> searchTag(@RequestParam String q, @RequestParam int limit) {
+        return communityService.searchTag(q,limit);
     }
 }

--- a/src/main/java/com/example/domain/community/Post.java
+++ b/src/main/java/com/example/domain/community/Post.java
@@ -31,6 +31,9 @@ public class Post {
     @Column(name = "created_time")
     private LocalDateTime createdTime;
 
+    @Column(name = "modified_time")
+    private LocalDateTime modifiedTime;
+
     private int views;
 
     @OneToMany(mappedBy = "post", cascade = CascadeType.ALL, orphanRemoval = true)

--- a/src/main/java/com/example/dto/response/MyPostResponse.java
+++ b/src/main/java/com/example/dto/response/MyPostResponse.java
@@ -16,6 +16,8 @@ public class MyPostResponse {
 
     @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss")
     private LocalDateTime createdAt;
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss")
+    private LocalDateTime modifiedAt;
     private List<String> postImagePathUrls;
     private Author author;
     private List<String> tags;

--- a/src/main/java/com/example/dto/response/PostsByTagInfoResponse.java
+++ b/src/main/java/com/example/dto/response/PostsByTagInfoResponse.java
@@ -1,6 +1,7 @@
 package com.example.dto.response;
 
 import com.example.domain.community.Photo;
+import com.fasterxml.jackson.annotation.JsonFormat;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.Setter;
@@ -15,8 +16,10 @@ public class PostsByTagInfoResponse {
     private Long postId;
     private String title;
     private String content;
-    private String createdAt;
-//    private String modifiedAt;
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss")
+    private LocalDateTime createdAt;
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss")
+    private LocalDateTime modifiedAt;
     private List<PhotoDto> postImagePathUrls;
     private AuthorDto author;
     private List<TagsDto> tags;
@@ -66,7 +69,8 @@ public class PostsByTagInfoResponse {
     public static class CommentDto {
         private String comment;
         private int likeCount;
-        private String createdAt;
+        @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss")
+        private LocalDateTime createdAt;
         private AuthorDto writer;
         private List<ReplyDto> replies;
 
@@ -76,7 +80,8 @@ public class PostsByTagInfoResponse {
         public static class ReplyDto {
             private String reply;
             private int likeCount;
-            private String createdAt;
+            @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss")
+            private LocalDateTime createdAt;
             private AuthorDto writer;
         }
     }

--- a/src/main/java/com/example/dto/response/PostsByTagInfoResponse.java
+++ b/src/main/java/com/example/dto/response/PostsByTagInfoResponse.java
@@ -67,7 +67,8 @@ public class PostsByTagInfoResponse {
     @Setter
     @Builder
     public static class CommentDto {
-        private String comment;
+        private Long commentId;
+        private String commentContent;
         private int likeCount;
         @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss")
         private LocalDateTime createdAt;
@@ -78,7 +79,8 @@ public class PostsByTagInfoResponse {
         @Setter
         @Builder
         public static class ReplyDto {
-            private String reply;
+            private Long replyId;
+            private String replyContent;
             private int likeCount;
             @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss")
             private LocalDateTime createdAt;

--- a/src/main/java/com/example/dto/response/SearchResponse.java
+++ b/src/main/java/com/example/dto/response/SearchResponse.java
@@ -1,0 +1,17 @@
+package com.example.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class SearchResponse {
+    private List<TagInfoResponse> relatedTags; // 연관 태그
+    private List<PostsByTagInfoResponse> posts; // 검색된 게시글들
+}

--- a/src/main/java/com/example/dto/response/SearchTagsResponse.java
+++ b/src/main/java/com/example/dto/response/SearchTagsResponse.java
@@ -1,0 +1,20 @@
+package com.example.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class SearchTagsResponse {
+    private Long tagId;
+    private String tag;
+    private Long postsCount;
+    private List<TagInfoResponse> relatedTags; // 연관 태그
+    private List<PostsByTagInfoResponse> posts; // 검색된 게시글들
+}

--- a/src/main/java/com/example/exception/ErrorCode.java
+++ b/src/main/java/com/example/exception/ErrorCode.java
@@ -37,6 +37,7 @@ public enum ErrorCode {
     COMMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 댓글이 없습니다."),
     REPLY_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 답글이 없습니다."),
     SUBSCRIPTION_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 태그를 구독하고 있지 않습니다"),
+    SEARCH_RESULTS_NOT_FOUND(HttpStatus.NOT_FOUND, "검색 결과가 없습니다."),
 
     // 409 CONFLICT
     ALREADY_EXIST_USERID(HttpStatus.CONFLICT, "이미 존재하는 아이디입니다."),

--- a/src/main/java/com/example/repository/community/CommentLikeRepository.java
+++ b/src/main/java/com/example/repository/community/CommentLikeRepository.java
@@ -5,4 +5,5 @@ import com.example.domain.community.CommentLikeId;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface CommentLikeRepository extends JpaRepository<CommentLike, CommentLikeId> {
+    int countByCommentId(Long commentId);
 }

--- a/src/main/java/com/example/repository/community/PostRepository.java
+++ b/src/main/java/com/example/repository/community/PostRepository.java
@@ -4,7 +4,9 @@ import com.example.domain.community.Post;
 import com.example.domain.member.Member;
 import io.lettuce.core.dynamic.annotation.Param;
 import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 
@@ -16,5 +18,15 @@ public interface PostRepository extends JpaRepository<Post, Long> {
     @Query("SELECT COUNT(p) FROM PostTag p WHERE p.tag.id = :tagId")
     Long countPostsByTagId(@Param("tagId") Long tagId);
     @Query("SELECT p FROM Post p JOIN p.postTags pt JOIN pt.tag t WHERE t.tagName = :tag ORDER BY p.createdTime DESC")
-    Page<Post> findByTagName(@Param("tag") String tag, Pageable pageable);
+    List<Post> findByTagName(@Param("tag") String tag, Sort sort);
+
+    @Query("SELECT p FROM Post p " +
+            "LEFT JOIN p.postTags pt " +
+            "LEFT JOIN pt.tag t " +
+            "LEFT JOIN p.member m " +
+            "WHERE LOWER(p.title) LIKE LOWER(CONCAT('%', :query, '%')) " +
+            "OR LOWER(p.content) LIKE LOWER(CONCAT('%', :query, '%')) " +
+            "OR LOWER(t.tagName) LIKE LOWER(CONCAT('%', :query, '%')) " +
+            "OR LOWER(m.username) LIKE LOWER(CONCAT('%', :query, '%'))")
+    List<Post> findByTitleOrContentOrTagNameOrAuthor(@Param("query") String query, Sort sort);
 }

--- a/src/main/java/com/example/repository/community/PostTagRepository.java
+++ b/src/main/java/com/example/repository/community/PostTagRepository.java
@@ -13,6 +13,9 @@ import java.util.List;
 public interface PostTagRepository extends JpaRepository<PostTag, Long> {
     List<PostTag> findByPost(Post post);
 
+    // 특정 태그와 관련된 게시글 수 계산
+    @Query("SELECT COUNT(pt) FROM PostTag pt WHERE pt.tag.id = :tagId")
+    Long countPostsByTagId(@Param("tagId") Long tagId);
 
     //태그 등록 수가 가장 높은 상위 태그 목록 조회
     @Query("SELECT pt.tag, COUNT(pt.post) FROM PostTag pt GROUP BY pt.tag ORDER BY COUNT(pt.post) DESC")

--- a/src/main/java/com/example/repository/community/ReplyLikeRepository.java
+++ b/src/main/java/com/example/repository/community/ReplyLikeRepository.java
@@ -5,4 +5,6 @@ import com.example.domain.community.ReplyLikeId;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface ReplyLikeRepository extends JpaRepository<ReplyLike, ReplyLikeId> {
+    int countByReplyId(Long replyId);
+
 }

--- a/src/main/java/com/example/service/community/CommunityService.java
+++ b/src/main/java/com/example/service/community/CommunityService.java
@@ -434,7 +434,8 @@ public class CommunityService {
 
                     List<PostsByTagInfoResponse.CommentDto.ReplyDto> replyDtos = replies.stream()
                             .map(reply -> PostsByTagInfoResponse.CommentDto.ReplyDto.builder()
-                                    .reply(reply.getContent())
+                                    .replyId(reply.getId())
+                                    .replyContent(reply.getContent())
                                     .likeCount(replyLikeRepository.countByReplyId(reply.getId()))
                                     .createdAt(reply.getCreatedTime())
                                     .writer(PostsByTagInfoResponse.AuthorDto.builder()
@@ -446,7 +447,8 @@ public class CommunityService {
                             .collect(Collectors.toList());
 
                     return PostsByTagInfoResponse.CommentDto.builder()
-                            .comment(comment.getPostContent())
+                            .commentId(comment.getId())
+                            .commentContent(comment.getPostContent())
                             .likeCount(commentLikeRepository.countByCommentId(comment.getId()))
                             .createdAt(comment.getCreatedTime())
                             .writer(PostsByTagInfoResponse.AuthorDto.builder()

--- a/src/main/java/com/example/service/community/CommunityService.java
+++ b/src/main/java/com/example/service/community/CommunityService.java
@@ -8,10 +8,7 @@ import com.example.domain.plan.Plan;
 import com.example.domain.service.Service;
 import com.example.dto.request.CreatePostRequest;
 import com.example.dto.request.UpdatePostRequest;
-import com.example.dto.response.CommunityPostResponse;
-import com.example.dto.response.MyPostResponse;
-import com.example.dto.response.PostsByTagInfoResponse;
-import com.example.dto.response.TagInfoResponse;
+import com.example.dto.response.*;
 import com.example.exception.CustomException;
 import com.example.exception.ErrorCode;
 import com.example.repository.community.*;
@@ -29,10 +26,10 @@ import org.springframework.data.domain.Sort;
 import org.springframework.security.core.Authentication;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.awt.print.Pageable;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 @org.springframework.stereotype.Service
@@ -52,6 +49,8 @@ public class CommunityService {
     private final CommentRepository commentRepository;
     private final ReplyRepository replyRepository;
     private final PostLikeRepository postLikeRepository;
+    private final CommentLikeRepository commentLikeRepository;
+    private final ReplyLikeRepository replyLikeRepository;
     private final PlanRepository planRepository;
 
 
@@ -77,6 +76,7 @@ public class CommunityService {
         post.setContent(postRequest.getContent());
         post.setMember(member);
         post.setCreatedTime(LocalDateTime.now());
+        post.setModifiedTime(LocalDateTime.now());
         post.setViews(0);
 
         post = postRepository.save(post);
@@ -131,7 +131,7 @@ public class CommunityService {
         // 제목, 내용, 생성 시기 수정 (post table)
         post.setTitle(updatePostRequest.getTitle());
         post.setContent(updatePostRequest.getContent());
-        post.setCreatedTime(LocalDateTime.now());
+        post.setModifiedTime(LocalDateTime.now());
 
         // 기존 태그, 서비스, 사진 삭제 (post_tags, post_services, photo table)
         deleteExistingPostTags(post);
@@ -212,48 +212,62 @@ public class CommunityService {
     }
 
     /**
-    내가 쓴 커뮤니티 게시글 목록 조회
+     추천 태그 목록 정보 조회
+     */
+    public ApiResult<?> getTop10Tags() {
+        List<Object[]> tagPostCounts = postTagRepository.findTopTagsWithPostCount();
+
+        if (tagPostCounts.isEmpty()) {
+            throw new CustomException(ErrorCode.SEARCH_RESULTS_NOT_FOUND);
+        }
+
+        List<TagInfoResponse> topTagsResponse = tagPostCounts.stream()
+                .limit(10)
+                .map(result -> {
+                    Tag tag = (Tag) result[0];
+                    Long postCount = (Long) result[1];
+                    return TagInfoResponse.builder()
+                            .tagId(tag.getId())
+                            .tagName(tag.getTagName())
+                            .postCount(postCount)
+                            .build();
+                })
+                .collect(Collectors.toList());
+
+        return ApiResult.success(topTagsResponse);
+    }
+
+    /**
+     연관 검색 태그 목록 정보 조회
+     */
+    public ApiResult<?> getRelatedTags(String query) {
+        List<TagInfoResponse> relatedTagsResponse = getRelatedTagsDto(query);
+
+        if (relatedTagsResponse.isEmpty()) {
+            throw new CustomException(ErrorCode.SEARCH_RESULTS_NOT_FOUND);
+        }
+
+        return ApiResult.success(relatedTagsResponse);
+    }
+
+
+    /**
+    내가 쓴 커뮤니티 게시글 목록 정보 조회
     */
-    public ApiResult<List<MyPostResponse>> getMyCommunityPosts(HttpServletRequest request) {
+    public ApiResult<List<PostsByTagInfoResponse>> getMyCommunityPosts(HttpServletRequest request) {
         String userId = getUserIdFromToken(request);
         Member member = memberRepository.findByUserId(userId)
                 .orElseThrow(() -> new CustomException(ErrorCode.MEMBER_NOT_FOUND));
 
         List<Post> posts = postRepository.findByMember(member);
 
-        List<MyPostResponse> response = posts.stream().map(post -> {
-            List<String> postImagePathUrls = post.getPhotos().stream()
-                    .map(Photo::getPhotoPath)
-                    .collect(Collectors.toList());
+        if (posts.isEmpty()) {
+            throw new CustomException(ErrorCode.SEARCH_RESULTS_NOT_FOUND);
+        }
 
-            List<String> tags = post.getPostTags().stream()
-                    .map(postTag -> postTag.getTag().getTagName())
-                    .collect(Collectors.toList());
-
-            int commentCount = commentRepository.countByPostId(post.getId());
-            int replyCount = replyRepository.countByCommentPostId(post.getId());
-            int totalCommentCount = commentCount + replyCount;
-            int likeCount = postLikeRepository.countByPostId(post.getId());
-
-
-            return MyPostResponse.builder()
-                    .postId(post.getId())
-                    .title(post.getTitle())
-                    .content(post.getContent())
-                    .createdAt(post.getCreatedTime())
-                    .postImagePathUrls(postImagePathUrls)
-                    .author(MyPostResponse.Author.builder()
-                            .memberId(member.getMemberId())
-                            .username(member.getUsername())
-                            .profileImagePathUrl(member.getProfile_path())
-                            .build())
-                    .tags(tags)
-                    .views(post.getViews())
-                    .commentCount(totalCommentCount)
-                    .likeCount(likeCount)
-                    .build();
-        }).collect(Collectors.toList());
-
+        List<PostsByTagInfoResponse> response = posts.stream()
+                .map(this::convertToDto)
+                .collect(Collectors.toList());
         return ApiResult.success(response);
     }
 
@@ -263,32 +277,166 @@ public class CommunityService {
     */
     public ApiResult<?> getPostsByTag(String tagName, int limit) {
 
-        PageRequest pageRequest = PageRequest.of(0, limit, Sort.by(Sort.Direction.DESC, "createdTime"));
-        Page<Post> postPage = postRepository.findByTagName(tagName, pageRequest);
+        List<Post> posts = postRepository.findByTagName(tagName, Sort.by(Sort.Direction.DESC, "createdTime"));
 
-        List<PostsByTagInfoResponse> response = postPage.stream()
+        if (posts.isEmpty()) {
+            throw new CustomException(ErrorCode.SEARCH_RESULTS_NOT_FOUND);
+        }
+
+        // limit에 따른 결과 제한
+        List<PostsByTagInfoResponse> response = posts.stream()
+                .limit(limit)
                 .map(this::convertToDto)
                 .collect(Collectors.toList());
 
         return ApiResult.success(response);
     }
 
+    /**
+     * 커뮤니티 게시글 정보 조회
+     */
+    public ApiResult<PostsByTagInfoResponse> getPostById(Long postId) {
+        Post post = postRepository.findById(postId)
+                .orElseThrow(() -> new CustomException(ErrorCode.POST_NOT_FOUND));
+
+        PostsByTagInfoResponse response = convertToDto(post);
+        return ApiResult.success(response);
+    }
+
+    /**
+     * 최신 커뮤니티 게시글 목록 조회
+     */
+    public ApiResult<List<PostsByTagInfoResponse>> getLatestPosts(int limit) {
+        List<Post> posts = postRepository.findAll(Sort.by(Sort.Direction.DESC, "createdTime"));
+
+        if (posts.isEmpty()) {
+            throw new CustomException(ErrorCode.SEARCH_RESULTS_NOT_FOUND);
+        }
+
+        // limit에 따른 결과 제한
+        List<PostsByTagInfoResponse> response = posts.stream()
+                .limit(limit)
+                .map(this::convertToDto)
+                .collect(Collectors.toList());
+
+        return ApiResult.success(response);
+    }
+
+    /**
+     * 게시글 검색 정보 조회
+     */
+    public ApiResult<?> searchQuery(String query, int limit) {
+        List<PostsByTagInfoResponse> posts = getPostsByQuery(query, limit);
+        List<TagInfoResponse> relatedTags = getRelatedTagsDto(query);
+
+        if (posts.isEmpty() && relatedTags.isEmpty()) {
+            throw new CustomException(ErrorCode.SEARCH_RESULTS_NOT_FOUND);
+        }
+
+        return ApiResult.success(SearchResponse.builder()
+                .relatedTags(relatedTags)
+                .posts(posts)
+                .build());
+    }
+
+    /**
+     * 태그 관련 통합 검색 정보 조회
+     */
+    public ApiResult<?> searchTag(String query, int limit) {
+        // 검색된 태그 조회
+        Optional<Tag> optionalTag = tagRepository.findByTagName(query);
+        List<PostsByTagInfoResponse> posts = getPostsByQuery(query, limit);
+        List<TagInfoResponse> relatedTags = getRelatedTagsFilterDto(query);
+
+        // 태그가 존재하지 않는 경우
+        if (optionalTag.isEmpty()) {
+
+            // 관련 태그와 게시글이 모두 없는 경우 404 오류 반환
+            if (posts.isEmpty() && relatedTags.isEmpty()) {
+                throw new CustomException(ErrorCode.SEARCH_RESULTS_NOT_FOUND);
+            }
+
+            return ApiResult.success(SearchTagsResponse.builder()
+                    .tagId(null)
+                    .tag(null)
+                    .postsCount(null)
+                    .relatedTags(relatedTags)
+                    .posts(posts)
+                    .build());
+        }
+
+        Tag tag = optionalTag.get();
+
+        // 태그와 관련된 게시글 수 계산
+        Long postsCount = postTagRepository.countPostsByTagId(tag.getId());
+
+        return ApiResult.success(SearchTagsResponse.builder()
+                .tagId(tag.getId())
+                .tag(tag.getTagName())
+                .postsCount(postsCount)
+                .relatedTags(relatedTags)
+                .posts(posts)
+                .build());
+    }
+
+    private List<TagInfoResponse> getRelatedTagsDto(String query) {
+        // 연관 태그 조회 및 DTO 변환
+        List<Object[]> relatedTags = postTagRepository.findRelatedTagsWithPostCount(query);
+        return relatedTags.stream()
+                .map(result -> {
+                    Tag tag = (Tag) result[0];
+                    Long postCount = (Long) result[1];
+                    return TagInfoResponse.builder()
+                            .tagId(tag.getId())
+                            .tagName(tag.getTagName())
+                            .postCount(postCount)
+                            .build();
+                })
+                .collect(Collectors.toList());
+    }
+
+    private List<TagInfoResponse> getRelatedTagsFilterDto(String query) {
+        // 연관 태그 조회 및 DTO 변환
+        List<Object[]> relatedTags = postTagRepository.findRelatedTagsWithPostCount(query);
+        return relatedTags.stream()
+                .map(result -> {
+                    Tag tag = (Tag) result[0];
+                    Long postCount = (Long) result[1];
+                    return TagInfoResponse.builder()
+                            .tagId(tag.getId())
+                            .tagName(tag.getTagName())
+                            .postCount(postCount)
+                            .build();
+                })
+                .filter(tagInfo -> !tagInfo.getTagName().equals(query)) // 쿼리 태그 제외
+                .collect(Collectors.toList());
+    }
+
+    private List<PostsByTagInfoResponse> getPostsByQuery(String query, int limit) {
+        List<Post> posts = postRepository.findByTitleOrContentOrTagNameOrAuthor(query, Sort.by(Sort.Direction.DESC, "createdTime"));
+
+        return posts.stream()
+                .limit(limit)
+                .map(this::convertToDto)
+                .collect(Collectors.toList());
+    }
 
     private PostsByTagInfoResponse convertToDto(Post post) {
         List<PostTag> postTags = postTagRepository.findByPost(post);
         List<Photo> photos = photoRepository.findByPost(post);
         List<PostService> postServices = postServiceRepository.findByPost(post);
         List<Comment> comments = commentRepository.findByPost(post);
+        int postLikeCount = postLikeRepository.countByPostId(post.getId());
         List<PostsByTagInfoResponse.CommentDto> commentDtos = comments.stream()
                 .map(comment -> {
-                    // 리플라이 조회
+                    // reply 조회
                     List<Reply> replies = replyRepository.findByCommentId(comment.getId());
 
                     List<PostsByTagInfoResponse.CommentDto.ReplyDto> replyDtos = replies.stream()
                             .map(reply -> PostsByTagInfoResponse.CommentDto.ReplyDto.builder()
                                     .reply(reply.getContent())
-//                                            .likeCount(reply.getLikeCount())
-                                    .createdAt(reply.getCreatedTime().format(DateTimeFormatter.ISO_DATE_TIME))
+                                    .likeCount(replyLikeRepository.countByReplyId(reply.getId()))
+                                    .createdAt(reply.getCreatedTime())
                                     .writer(PostsByTagInfoResponse.AuthorDto.builder()
                                             .memberId(reply.getMember().getMemberId())
                                             .username(reply.getMember().getUsername())
@@ -299,8 +447,8 @@ public class CommunityService {
 
                     return PostsByTagInfoResponse.CommentDto.builder()
                             .comment(comment.getPostContent())
-//                            .likeCount(comment.getLikeCount())
-                            .createdAt(comment.getCreatedTime().format(DateTimeFormatter.ISO_DATE_TIME))
+                            .likeCount(commentLikeRepository.countByCommentId(comment.getId()))
+                            .createdAt(comment.getCreatedTime())
                             .writer(PostsByTagInfoResponse.AuthorDto.builder()
                                     .memberId(comment.getMember().getMemberId())
                                     .username(comment.getMember().getUsername())
@@ -316,8 +464,8 @@ public class CommunityService {
                 .postId(post.getId())
                 .title(post.getTitle())
                 .content(post.getContent())
-                .createdAt(post.getCreatedTime().format(DateTimeFormatter.ISO_DATE_TIME))
-                //.modifiedAt(post.getModifiedAt()) modifiedAt 속성 추가시 추가 예정
+                .createdAt(post.getCreatedTime())
+                .modifiedAt(post.getModifiedTime())
                 .postImagePathUrls(photos.stream()
                         .map(photo -> PostsByTagInfoResponse.PhotoDto.builder()
                                 .photoPath(photo.getPhotoPath())
@@ -346,177 +494,7 @@ public class CommunityService {
                                 .build())
                         .collect(Collectors.toList()))
                 .comments(commentDtos)
-                .likeCount(postLikeRepository.countByPostId(post.getId()))
-                .build();
-    }
-
-
-    /**
-    추천 태그 목록 정보 조회
-    */
-    public ApiResult<?> getTop10Tags() {
-        List<Object[]> tagPostCounts = postTagRepository.findTopTagsWithPostCount();
-
-        List<TagInfoResponse> topTagsResponse = tagPostCounts.stream()
-                .limit(10)
-                .map(result -> {
-                    Tag tag = (Tag) result[0];
-                    Long postCount = (Long) result[1];
-                    return TagInfoResponse.builder()
-                            .tagId(tag.getId())
-                            .tagName(tag.getTagName())
-                            .postCount(postCount)
-                            .build();
-                })
-                .collect(Collectors.toList());
-
-        return ApiResult.success(topTagsResponse);
-    }
-
-    /*
-    연관 검색 태그 목록 정보 조회
-    */
-    public ApiResult<?> getRelatedTags(String query) {
-        List<Object[]> tagPostCounts = postTagRepository.findRelatedTagsWithPostCount(query);
-
-        List<TagInfoResponse> relatedTagsResponse = tagPostCounts.stream()
-                .map(result -> {
-                    Tag tag = (Tag) result[0];
-                    Long postCount = (Long) result[1];
-                    return TagInfoResponse.builder()
-                            .tagId(tag.getId())
-                            .tagName(tag.getTagName())
-                            .postCount(postCount)
-                            .build();
-                })
-                .collect(Collectors.toList());
-
-        return ApiResult.success(relatedTagsResponse);
-    }
-
-    /**
-     * 커뮤니티 게시글 정보 조회
-     */
-    public ApiResult<CommunityPostResponse> getPostById(Long postId) {
-        Post post = postRepository.findById(postId)
-                .orElseThrow(() -> new CustomException(ErrorCode.POST_NOT_FOUND));
-
-        CommunityPostResponse response = convertToCommunityPostResponseDto(post);
-        return ApiResult.success(response);
-    }
-
-    private CommunityPostResponse convertToCommunityPostResponseDto(Post post) {
-        List<PostTag> postTags = postTagRepository.findByPost(post);
-        List<Photo> photos = photoRepository.findByPost(post);
-        List<PostService> postServices = postServiceRepository.findByPost(post);
-        List<Comment> comments = commentRepository.findByPost(post);
-
-        List<CommunityPostResponse.CommentDto> commentDtos = comments.stream()
-                .map(comment -> {
-                    List<Reply> replies = replyRepository.findByCommentId(comment.getId());
-                    List<CommunityPostResponse.CommentDto.ReplyDto> replyDtos = replies.stream()
-                            .map(reply -> CommunityPostResponse.CommentDto.ReplyDto.builder()
-                                    .reply(reply.getContent())
-                                    .createdAt(reply.getCreatedTime().format(DateTimeFormatter.ISO_DATE_TIME))
-                                    .writer(CommunityPostResponse.AuthorDto.builder()
-                                            .memberId(reply.getMember().getMemberId())
-                                            .username(reply.getMember().getUsername())
-                                            .profileImagePathUrl(reply.getMember().getProfile_path())
-                                            .build())
-                                    .build())
-                            .collect(Collectors.toList());
-
-                    return CommunityPostResponse.CommentDto.builder()
-                            .comment(comment.getPostContent())
-                            .createdAt(comment.getCreatedTime().format(DateTimeFormatter.ISO_DATE_TIME))
-                            .writer(CommunityPostResponse.AuthorDto.builder()
-                                    .memberId(comment.getMember().getMemberId())
-                                    .username(comment.getMember().getUsername())
-                                    .profileImagePathUrl(comment.getMember().getProfile_path())
-                                    .build())
-                            .replies(replyDtos)
-                            .build();
-                })
-                .collect(Collectors.toList());
-
-        return CommunityPostResponse.builder()
-                .postId(post.getId())
-                .title(post.getTitle())
-                .content(post.getContent())
-                .createdAt(post.getCreatedTime().format(DateTimeFormatter.ISO_DATE_TIME))
-                .postImagePathUrls(photos.stream()
-                        .map(Photo::getPhotoPath)
-                        .collect(Collectors.toList()))
-                .author(CommunityPostResponse.AuthorDto.builder()
-                        .memberId(post.getMember().getMemberId())
-                        .username(post.getMember().getUsername())
-                        .profileImagePathUrl(post.getMember().getProfile_path())
-                        .build())
-                .tags(postTags.stream()
-                        .map(postTag -> CommunityPostResponse.TagDto.builder()
-                                .tagId(postTag.getTag().getId())
-                                .tag(postTag.getTag().getTagName())
-                                .build())
-                        .collect(Collectors.toList()))
-                .views(post.getViews())
-                .services(postServices.stream()
-                        .map(postService -> CommunityPostResponse.ServiceDto.builder()
-                                .serviceId(postService.getService().getId())
-                                .planIds(planRepository.findByService_Id(postService.getService().getId()).stream()
-                                        .map(Plan::getId)
-                                        .collect(Collectors.toList()))
-                                .name(postService.getService().getServiceName())
-                                .url(postService.getService().getUrl())
-                                .build())
-                        .collect(Collectors.toList()))
-                .comments(commentDtos)
-                .likeCount(postLikeRepository.countByPostId(post.getId()))
-                .build();
-    }
-
-    /**
-     * 최신 커뮤니티 게시글 목록 조회
-     */
-    public ApiResult<List<CommunityPostResponse>> getLatestPosts(int limit) {
-        PageRequest pageRequest = PageRequest.of(0, limit, Sort.by(Sort.Direction.DESC, "createdTime"));
-        List<Post> posts = postRepository.findAll(pageRequest).getContent();
-
-        List<CommunityPostResponse> response = posts.stream()
-                .map(this::convertPostToCommunityPostResponse)
-                .collect(Collectors.toList());
-
-        return ApiResult.success(response);
-    }
-
-    private CommunityPostResponse convertPostToCommunityPostResponse(Post post) {
-        List<String> postImagePathUrls = post.getPhotos().stream()
-                .map(Photo::getPhotoPath)
-                .collect(Collectors.toList());
-
-        List<CommunityPostResponse.TagDto> tags = post.getPostTags().stream()
-                .map(postTag -> CommunityPostResponse.TagDto.builder()
-                        .tagId(postTag.getTag().getId())
-                        .tag(postTag.getTag().getTagName())
-                        .build())
-                .collect(Collectors.toList());
-
-        int commentCount = commentRepository.countByPostId(post.getId());
-
-        return CommunityPostResponse.builder()
-                .postId(post.getId())
-                .title(post.getTitle())
-                .content(post.getContent())
-                .createdAt(post.getCreatedTime().format(DateTimeFormatter.ISO_DATE_TIME))
-                .postImagePathUrls(postImagePathUrls)
-                .author(CommunityPostResponse.AuthorDto.builder()
-                        .memberId(post.getMember().getMemberId())
-                        .username(post.getMember().getUsername())
-                        .profileImagePathUrl(post.getMember().getProfile_path())
-                        .build())
-                .tags(tags)
-                .views(post.getViews())
-                .commentCount(commentCount)
-                .likeCount(postLikeRepository.countByPostId(post.getId()))
+                .likeCount(postLikeCount)
                 .build();
     }
 }


### PR DESCRIPTION
## 👀 이슈

resolve #108

## 📌 개요

게시글 검색 정보 조회, 태그 관련 통합 검색 정보를 조회하고자 합니다.

## 👩‍💻 작업 사항

### 1. 게시글 검색 정보 조회
- **API:** `GET /public/community/search/posts?q=도라에몽&limit=10`
- **설명:** 
  - 검색된 `query` 값과 관련된 연관 커뮤니티 태그 목록 정보와 (게시글 제목, 내용, 게시글 내 등록된 태그, 작성자명) 중 하나라도 일치하는 게시글에 대한 정보를 반환합니다.
  - `limit` 파라미터는 날짜가 최신인 게시글들의 조회 개수를 제한하는 역할을 하며, 조정이 가능합니다.
  - **예외 상황:** 관련된 정보가 하나도 존재하지 않는 경우 `404` 에러를 반환합니다.

### 2. 태그 관련 통합 검색 정보 조회
- **API:** `GET /public/community/search/tags?q=도라에몽&limit=10`
- **설명:** 
  - 검색된 `query` 값과 일치하는 커뮤니티 태그 및 연관 커뮤니티 태그 목록 정보와 (게시글 제목, 내용, 게시글 내 등록된 태그, 작성자명) 중 하나라도 일치하는 게시글에 대한 정보를 반환합니다.
  - `relatedSearchTag` 객체에는 검색된 태그를 제외한 나머지 연관 커뮤니티 태그 목록 정보가 포함되어야 합니다.
  - `limit` 파라미터는 최신 게시글들의 조회 개수를 제한하며, 조정이 가능합니다.
  - **예외 상황:** DB에 `도라에몽`에 대한 태그 데이터가 존재하지 않는 경우, 클라이언트가 해당 API를 호출할 때 (`GET /public/community/search/tags?q=도라에몽&limit=10`) `tagId`, `tag`, `postsCount` 값은 모두 `null`로 대체하여 응답합니다.

### 3. 목록 정보 조회 관련 API 통합 수정
- **수정 사항:**
  - `response body` 통일
  - 관련된 정보가 존재하지 않는 경우 `404` 에러를 반환합니다. (에러 코드: `SEARCH_RESULTS_NOT_FOUND`, 메시지: `검색 결과가 없습니다.`)
  - 목록 정보 조회 `limit` 관련 오류 수정

## ✅ 참고 사항

113번 issue가 앞입니다!