### PR TITLE
[feat] 인기 커뮤니티 게시글 목록 정보 조회 기능 추가 / 조회수 증가 로직 추가

### DIFF
--- a/src/main/java/com/example/controller/community/CommunityController.java
+++ b/src/main/java/com/example/controller/community/CommunityController.java
@@ -79,6 +79,13 @@ public class CommunityController {
         return communityService.getLatestPosts(limit);
     }
 
+    @Operation(summary = "인기 커뮤니티 게시글 목록 정보 조회", description = "")
+    @GetMapping("/public/community/posts/hot")
+    public ApiResult<List<PostsByTagInfoResponse>> getHotPosts() {
+        return communityService.getHotPosts();
+    }
+
+
     @Operation(summary = "게시글 검색 정보 조회", description = "")
     @GetMapping("/public/community/search/posts")
     public ApiResult<?> searchQuery(@RequestParam String q, @RequestParam int limit) {

--- a/src/main/java/com/example/repository/community/PostRepository.java
+++ b/src/main/java/com/example/repository/community/PostRepository.java
@@ -15,6 +15,8 @@ import java.util.List;
 public interface PostRepository extends JpaRepository<Post, Long> {
     List<Post> findByMember(Member member);
 
+    @Query("SELECT p FROM Post p ORDER BY p.views DESC, p.createdTime DESC")
+    List<Post> findTop5ByViews(Pageable pageable);
     @Query("SELECT COUNT(p) FROM PostTag p WHERE p.tag.id = :tagId")
     Long countPostsByTagId(@Param("tagId") Long tagId);
     @Query("SELECT p FROM Post p JOIN p.postTags pt JOIN pt.tag t WHERE t.tagName = :tag ORDER BY p.createdTime DESC")

--- a/src/main/java/com/example/service/community/CommunityService.java
+++ b/src/main/java/com/example/service/community/CommunityService.java
@@ -326,8 +326,27 @@ public class CommunityService {
     }
 
     /**
-     * 게시글 검색 정보 조회
+     * 인기 커뮤니티 게시글 목록 조회
      */
+    public ApiResult<List<PostsByTagInfoResponse>> getHotPosts() {
+        List<Post> hotPosts = postRepository.findTop5ByViews(PageRequest.of(0, 5));
+
+        if (hotPosts.isEmpty()) {
+            throw new CustomException(ErrorCode.SEARCH_RESULTS_NOT_FOUND);
+        }
+
+        List<PostsByTagInfoResponse> response = hotPosts.stream()
+                .map(this::convertToDto)
+                .collect(Collectors.toList());
+
+        return ApiResult.success(response);
+    }
+
+
+
+     /**
+      * 게시글 검색 정보 조회
+      */
     public ApiResult<?> searchQuery(String query, int limit) {
         List<PostsByTagInfoResponse> posts = getPostsByQuery(query, limit);
         List<TagInfoResponse> relatedTags = getRelatedTagsDto(query);

--- a/src/main/java/com/example/service/community/CommunityService.java
+++ b/src/main/java/com/example/service/community/CommunityService.java
@@ -299,6 +299,9 @@ public class CommunityService {
         Post post = postRepository.findById(postId)
                 .orElseThrow(() -> new CustomException(ErrorCode.POST_NOT_FOUND));
 
+        post.setViews(post.getViews() + 1);
+        postRepository.save(post);
+
         PostsByTagInfoResponse response = convertToDto(post);
         return ApiResult.success(response);
     }


### PR DESCRIPTION
## 👀 이슈

resolve #118

## 📌 개요

인기 커뮤니티 게시글 목록 정보를 조회합니다.
커뮤니티 게시글 정보 조회 API에 조회수 증가 로직을 추가합니다.

## 👩‍💻 작업 사항

- 인기 커뮤니티 게시글 목록 정보 조회
  - GET, /public/community/posts/hot)
  - 커뮤니티 내 전체 게시글 중에서 게시글의 조회수(views)가 가장 높은 상위 5개의 게시글 정보를 조회한다.

- 커뮤니티 게시글 정보 조회
  -  API 사용 시 해당 게시글에 해당하는 views + 1으로 증가시킨다.

## ✅ 참고 사항

게시글의 조회수가 같을 경우 최근 작성된 게시글을 우선으로 반환합니다.
