### PR TITLE
[fix] 파티 매칭 완료시 이메일 전송 서비스 로직 수정 및 기능 개선 #122

### DIFF
--- a/src/main/java/com/example/BuddyApplication.java
+++ b/src/main/java/com/example/BuddyApplication.java
@@ -3,9 +3,11 @@ package com.example;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.scheduling.annotation.EnableAsync;
 
 @SpringBootApplication
 @EnableJpaAuditing
+@EnableAsync
 public class BuddyApplication {
 
     public static void main(String[] args) {

--- a/src/main/java/com/example/config/async/AsyncConfig.java
+++ b/src/main/java/com/example/config/async/AsyncConfig.java
@@ -1,0 +1,24 @@
+package com.example.config.async;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableAsync;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+
+import java.util.concurrent.Executor;
+
+@Configuration
+@EnableAsync
+public class AsyncConfig {
+
+    @Bean(name = "taskExecutor")
+    public Executor taskExecutor() {
+        ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+        executor.setCorePoolSize(2);
+        executor.setMaxPoolSize(10);
+        executor.setQueueCapacity(500);
+        executor.setThreadNamePrefix("Async-");
+        executor.initialize();
+        return executor;
+    }
+}

--- a/src/main/java/com/example/service/email/EmailService.java
+++ b/src/main/java/com/example/service/email/EmailService.java
@@ -6,6 +6,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.mail.javamail.JavaMailSender;
 import org.springframework.mail.javamail.MimeMessageHelper;
+import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
 
 
@@ -16,6 +17,8 @@ public class EmailService {
 
     private final JavaMailSender mailSender;
 
+
+    @Async
     public void sendEmail(String to, String subject, String htmlContent) {
         MimeMessage mimeMessage = mailSender.createMimeMessage();
         try {


### PR DESCRIPTION
## 👀 이슈

resolve #112

## 📌 개요

파티의 마지막 멤버가 파티에 가입할 때, 해당 파티의 모든 파티원에게 파티 매칭 완료 이메일 전송을 함으로 인해 파티 가입 완료 알림이 지연됩니다.

## 👩‍💻 작업 사항

- 이메일 발송 메서드(sendEmail)에 @Async 적용하여 비동기 처리 구현

## ✅ 참고 사항

공유할 내용 및 관련 스크린샷 등을 넣어 주세요
