### PR TITLE
[bug] 특정 플랜 내 매칭이 완료되지 않은 파티 목록 정보 조회 API 응답 에러 #126

### DIFF
--- a/src/main/java/com/example/service/party/PartyService.java
+++ b/src/main/java/com/example/service/party/PartyService.java
@@ -148,16 +148,17 @@ public class PartyService {
                 .orElseThrow(() -> new CustomException(ErrorCode.PLAN_NOT_FOUND));
 
         List<Party> parties = partyRepository.findUnmatchedPartiesByPlanIdAndNotMember(planId, member);
-        LocalDate today = LocalDate.now();
+        LocalDateTime now = LocalDateTime.now();
 
         List<UnmatchedPartiesInfoResponse.PartyDto> responseList = parties.stream()
+                .filter(party -> party.getStartDate().isAfter(now) || party.getStartDate().isEqual(now))
                 .map(party -> UnmatchedPartiesInfoResponse.PartyDto.builder()
-                .partyId(party.getPartyId())
-                .startDate(party.getStartDateISOString())
-                .durationMonth(party.getDurationMonth())
-                .endDate(party.getEndDateISOString())
-                .individualMonthlyFee(party.getPlan().getMonthlyFee() / (party.getRecLimit() + 1))
-                .build()).collect(Collectors.toList());
+                    .partyId(party.getPartyId())
+                    .startDate(party.getStartDateISOString())
+                    .durationMonth(party.getDurationMonth())
+                    .endDate(party.getEndDateISOString())
+                    .individualMonthlyFee(party.getPlan().getMonthlyFee() / (party.getRecLimit() + 1))
+                    .build()).collect(Collectors.toList());
 
         UnmatchedPartiesInfoResponse.PlanDto planDto = UnmatchedPartiesInfoResponse.PlanDto.builder()
                 .name(plan.getPlanName())


### PR DESCRIPTION
## 👀 이슈

resolve #126

## 📌 개요
특정 플랜 내 매칭이 완료되지 않은 파티 목록 정보 조회 API 응답 에러 수정

## 👩‍💻 작업 사항

특정 플랜 내 매칭이 완료되지 않은 파티 목록 정보 조회 API에서 현재 파티의 시작일자(startDate)가 오늘보다 이전인 파티는 응답 바디를 포함하지 않도록 로직을 추가했습니다.

## ✅ 참고 사항

공유할 내용 및 관련 스크린샷 등을 넣어 주세요
