### PR TITLE
[bug] 현재 매칭 대기 중인 모든 파티의 파티원 총 인원수 합산 값 조회 API 응답 에러 #130

### DIFF
--- a/src/main/java/com/example/controller/party/PartyController.java
+++ b/src/main/java/com/example/controller/party/PartyController.java
@@ -119,8 +119,7 @@ public class PartyController {
      */
     @GetMapping("/public/party/waiting-members")
     @Operation(summary = "현재 매칭 대기 중인 모든 파티의 파티원 총 인원수 합산 값 조회", description = "")
-    public ApiResult<Integer> getWaitingMembersCount() {
-        int count = partyService.getWaitingMembersCount();
-        return ApiResult.success(count);
+    public ApiResult<?> getWaitingMembersCount() {
+        return partyService.getWaitingMembersCount();
     }
 }

--- a/src/main/java/com/example/repository/party/PartyRepository.java
+++ b/src/main/java/com/example/repository/party/PartyRepository.java
@@ -6,6 +6,7 @@ import io.lettuce.core.dynamic.annotation.Param;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 
@@ -25,8 +26,8 @@ public interface PartyRepository extends JpaRepository<Party, Long> {
             "LIMIT 5", nativeQuery = true)
     List<Object[]> findTop5HotServices();
 
-    @Query("SELECT SUM(p.currentRecNum) FROM Party p WHERE p.progressStatus = false")
-    Integer getWaitingMembersCount();
+    @Query("SELECT SUM(p.currentRecNum) FROM Party p WHERE p.startDate >= :currentDate AND p.progressStatus = false")
+    Integer getWaitingMembersCount(@Param("currentDate") LocalDateTime currentDate);
 
     List<Party> findByMemberAndProgressStatus(Member member, boolean progressStatus);
 }

--- a/src/main/java/com/example/service/party/PartyService.java
+++ b/src/main/java/com/example/service/party/PartyService.java
@@ -600,9 +600,12 @@ public class PartyService {
                 .build());
     }
 
-
-    public int getWaitingMembersCount() {
-        Integer count = partyRepository.getWaitingMembersCount();
-        return count != null ? count : 0;
+    /*
+    현재 매칭 대기 중인 모든 파티의 파티원 총 인원수 합산 값 조회
+     */
+    public ApiResult<?> getWaitingMembersCount() {
+        LocalDateTime now = LocalDateTime.now();
+        Integer count = partyRepository.getWaitingMembersCount(now);
+        return ApiResult.success(count != null ? count : 0);
     }
 }


### PR DESCRIPTION
## 👀 이슈

resolve #130 

## 📌 개요

현재 매칭 대기 중인 모든 파티의 파티원 총 인원수 합산 값 조회 API 응답 에러 수정

## 👩‍💻 작업 사항

현재 매칭 대기 중인 모든 파티의 파티원 총 인원수 합산 값 조회 API에서 현재 파티의 시작일자(startDate)가 오늘보다 이전인 파티원의 수도 합산에 포함됩니다. 해당 파티를 포함하지 않도록 로직을 추가했습니다.

## ✅ 참고 사항

공유할 내용 및 관련 스크린샷 등을 넣어 주세요
